### PR TITLE
#11 関連ファイルが変更された時だけCIが動くようにpathsフィルターを追加

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -1,7 +1,14 @@
 name: biome
 
 on:
-  pull_request
+  pull_request:
+    paths:
+      - 'source/**/*.ts'
+      - 'source/**/*.tsx'
+      - 'source/**/*.js'
+      - 'source/**/*.vue'
+      - 'source/package.json'
+      - 'source/pnpm-lock.yaml'
 
 jobs:
   phpstan:

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -1,7 +1,11 @@
 name: pest
 
 on:
-  pull_request
+  pull_request:
+    paths:
+      - 'source/**/*.php'
+      - 'source/composer.json'
+      - 'source/composer.lock'
 
 jobs:
   phpstan:

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,7 +1,11 @@
 name: pint
 
 on:
-  pull_request
+  pull_request:
+    paths:
+      - 'source/**/*.php'
+      - 'source/composer.json'
+      - 'source/composer.lock'
 
 jobs:
   phpstan:

--- a/.github/workflows/tc.yml
+++ b/.github/workflows/tc.yml
@@ -1,7 +1,13 @@
 name: tc
 
 on:
-  pull_request
+  pull_request:
+    paths:
+      - 'source/**/*.ts'
+      - 'source/**/*.tsx'
+      - 'source/**/*.php'
+      - 'source/package.json'
+      - 'source/pnpm-lock.yaml'
 
 jobs:
   phpstan:

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,7 +1,14 @@
 name: vitest
 
 on:
-  pull_request
+  pull_request:
+    paths:
+      - 'source/**/*.ts'
+      - 'source/**/*.tsx'
+      - 'source/**/*.js'
+      - 'source/**/*.vue'
+      - 'source/package.json'
+      - 'source/pnpm-lock.yaml'
 
 jobs:
   phpstan:


### PR DESCRIPTION
## Summary

- 各GitHub Actionsワークフローに`paths`フィルターを追加し、関連ファイルが変更された時だけ実行されるよう変更
- `pint` / `pest`: `*.php`、`composer.json`、`composer.lock` の変更時のみ実行
- `vitest` / `biome`: `*.ts`、`*.tsx`、`*.js`、`*.vue`、`package.json`、`pnpm-lock.yaml` の変更時のみ実行
- `tc`: `*.ts`、`*.tsx`、`*.php`（wayfinder用）、`package.json`、`pnpm-lock.yaml` の変更時のみ実行

## Test plan

- [ ] `.md` ファイルのみ変更したPRでCIが動かないことを確認
- [ ] `*.php` ファイルを変更したPRで `pint` / `pest` が動くことを確認
- [ ] `*.ts` ファイルを変更したPRで `vitest` / `biome` / `tc` が動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)