### PR TITLE
 CIでWayfinder生成ファイルが存在しないビルドエラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,22 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # ③.5 PHPセットアップ（Wayfinder生成ファイル用）
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+
+      - name: Install Composer dependencies
+        run: composer install --no-dev --prefer-dist --optimize-autoloader --no-interaction
+
+      - name: Generate Wayfinder TypeScript files
+        run: |
+          cp .env.example .env
+          php artisan key:generate --no-interaction
+          php artisan wayfinder:generate --with-form --no-interaction
+
       # ④ フロントビルド（★CIではここまで）
       - name: Build assets
         run: pnpm run build


### PR DESCRIPTION
## やったこと

- CIビルド時に `@/routes` / `@/actions` 配下のWayfinder生成ファイルが存在せずビルドが失敗していた問題を修正
- `vite.config.ts` でWayfinderのViteプラグインがCI環境では無効化（`\!isCI`）されており、かつ生成ファイルは `.gitignore` に含まれているため、CIではファイルが一切存在しない状態だった
- `pnpm run build` の前にPHPセットアップ・Composerインストール・`php artisan wayfinder:generate` を実行するステップを追加し、ビルド時点で生成ファイルが存在するようにした

## 結果

## 動作確認済み
- [ ] 