### PR TITLE
#85 deploy.yml に environment: github_actions を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: github_actions
 
     defaults:
       run:


### PR DESCRIPTION
## やったこと

- \`deploy\` ジョブに \`environment: github_actions\` を追加した
- これにより GitHub Actions が Environment secrets（SECRET_KEY, USER, HOST, ASSETS_BUILD_FILE_PATH, LARAVEL_DIR）を読み込めるようになる

## 結果

- Setup SSH ステップで全シークレットが空になっていた問題が解消される

## 動作確認済み

- [ ] CD が正常に完了することを確認