### PR TITLE
#87 リモートデプロイのSSHコマンドにbashを明示指定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
       # ⑦ サーバー側デプロイ（Laravel全部ここ）
       - name: Run remote deploy
         run: |
-          ssh ${USER}@${HOST} << 'EOF'
+          ssh ${USER}@${HOST} /bin/bash -s << 'EOF'
             set -e
 
             cd ${LARAVEL_DIR}


### PR DESCRIPTION
## やったこと

- レンタルサーバーのデフォルトシェルが `csh`/`tcsh` の場合に `set -e` が `Variable name must begin with a letter.` エラーになる問題を修正
- `ssh` コマンドに `/bin/bash -s` を明示指定することでサーバー側のシェル依存を解消

## 結果

（スクリーンショット・動画なし）

## 動作確認済み

- [ ] CI の Run remote deploy ステップがエラーなく完了すること