### PR TITLE
#89 SSHコマンドのbashをフルパス指定からPATH解決に変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
       # ⑦ サーバー側デプロイ（Laravel全部ここ）
       - name: Run remote deploy
         run: |
-          ssh ${USER}@${HOST} /bin/bash -s << 'EOF'
+          ssh ${USER}@${HOST} bash -s << 'EOF'
             set -e
 
             cd ${LARAVEL_DIR}


### PR DESCRIPTION
## やったこと

- レンタルサーバーでは bash が `/bin/bash` に存在しない場合があり、`/bin/bash: Command not found.` エラーになる問題を修正
- `ssh ${USER}@${HOST} /bin/bash -s` から `ssh ${USER}@${HOST} bash -s` に変更し、PATH から bash を自動解決させる

## 結果

（スクリーンショット・動画なし）

## 動作確認済み

- [ ] CI の Run remote deploy ステップがエラーなく完了すること