### PR TITLE
#91 ヒアドキュメントのクォートを外しLARVEL_DIRをCI環境で展開する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
       # ⑦ サーバー側デプロイ（Laravel全部ここ）
       - name: Run remote deploy
         run: |
-          ssh ${USER}@${HOST} << 'EOF'
+          ssh ${USER}@${HOST} bash -s << EOF
             set -e
 
             cd ${LARAVEL_DIR}


### PR DESCRIPTION
## やったこと

- ヒアドキュメントの区切り文字 `'EOF'`（シングルクォート）を `EOF`（クォートなし）に変更
- これにより `${LARAVEL_DIR}` が CI 環境でローカル展開されてからリモートサーバーに送られるようになり、`cd ${LARAVEL_DIR}` が正しいディレクトリに移動できる
- 修正前は `Could not open input file: artisan` / `fatal: not a git repository` エラーが発生していた

## 結果

（スクリーンショット・動画なし）

## 動作確認済み

- [ ] CI の Run remote deploy ステップが正しいディレクトリで実行されること