### PR TITLE
#93 ticket_typesに単複(tanpuku)を追加する

### DIFF
--- a/source/database/seeders/TicketTypeSeeder.php
+++ b/source/database/seeders/TicketTypeSeeder.php
@@ -22,6 +22,7 @@ class TicketTypeSeeder extends Seeder
             ['name' => 'wide', 'label' => 'ワイド', 'sort_order' => 6, 'created_at' => $now, 'updated_at' => $now],
             ['name' => 'sanrenpuku', 'label' => '三連複', 'sort_order' => 7, 'created_at' => $now, 'updated_at' => $now],
             ['name' => 'sanrentan', 'label' => '三連単', 'sort_order' => 8, 'created_at' => $now, 'updated_at' => $now],
+            ['name' => 'tanpuku', 'label' => '単複', 'sort_order' => 9, 'created_at' => $now, 'updated_at' => $now],
         ];
 
         DB::table('ticket_types')->insert($types);

--- a/source/tests/Feature/Tickets/TicketPurchaseTest.php
+++ b/source/tests/Feature/Tickets/TicketPurchaseTest.php
@@ -57,6 +57,60 @@ test('authenticated user can purchase a ticket', function () {
     ]);
 });
 
+test('単複で馬券購入を記録できる', function () {
+    // Arrange
+    $user = User::factory()->create();
+
+    $now = now();
+
+    DB::table('venues')->insert([
+        'name' => '東京',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $ticketType = DB::table('ticket_types')->insertGetId([
+        'name' => 'tanpuku',
+        'label' => '単複',
+        'sort_order' => 9,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $buyType = DB::table('buy_types')->insertGetId([
+        'name' => 'single',
+        'label' => '通常',
+        'sort_order' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->post(route('tickets.store'), [
+        'venue' => '東京',
+        'race_date' => '2026-04-11',
+        'race_number' => 1,
+        'ticket_type' => 'tanpuku',
+        'buy_type' => 'single',
+        'selections' => ['horses' => [5]],
+        'amount' => 200,
+    ]);
+
+    // Assert
+    $response->assertRedirect(route('tickets.new'));
+
+    $race = DB::table('races')->where('race_date', '2026-04-11')->where('race_number', 1)->first();
+    expect($race)->not->toBeNull();
+
+    $this->assertDatabaseHas('ticket_purchases', [
+        'user_id' => $user->id,
+        'race_id' => $race->id,
+        'ticket_type_id' => $ticketType,
+        'buy_type_id' => $buyType,
+        'amount' => 200,
+    ]);
+});
+
 test('レース結果登録済みの場合、馬券購入時に payout_amount が計算される', function () {
     // Arrange
     $user = User::factory()->create();


### PR DESCRIPTION
## やったこと

- `ticket_types` テーブルに `name=tanpuku, label=単複, sort_order=9` のレコードを `TicketTypeSeeder` に追加
- 単複で馬券購入を記録できることを確認するフィーチャーテストを追加

## 結果

特になし（UIに影響なし）

## 動作確認済み

- [x] 単複で馬券購入を記録できるテスト（`単複で馬券購入を記録できる`）がパス