### PR TITLE
[patch] dev-implのStep4テスト検証観点を修正する

### DIFF
--- a/.claude/skills/dev-impl/SKILL.md
+++ b/.claude/skills/dev-impl/SKILL.md
@@ -125,9 +125,10 @@ general-purposeエージェントへの指示例:
 以下の順序でチェックする:
 
 **1. テスト結果の確認**
-- ステップ3で作成したテストがすべてパスしているか
-- Step2で作成した補助テストがすべてパスしているか
-- テストランナーのコマンドは `docs/architecture/` または `package.json`/`README.md` から判断する
+- テストスイートがすべてパスしているか
+  - テストランナーのコマンドは `docs/architecture/` または `package.json`/`README.md` から判断する
+- 実装準備フェーズ（ステップ3）でissueに記録された承認済みテスト計画の各項目が実装されており、壊れていないか
+  - `gh issue view <番号> --comments` で承認済みテスト計画コメントを取得して確認する
 
 **2. 仕様準拠の確認**
 - `docs/specs/` の確定仕様（openapi.yaml・api-list.md・screen-list.md等）と実装が一致しているか


### PR DESCRIPTION
## やったこと

- `dev-impl` スキルの Step 4（セルフレビュー）のテスト結果確認の観点を修正
- 「ステップ3で作成したテスト」という不正確な表現（dev-impl内のStep 3は実装フェーズのためテストを作成しない）を削除
- テスト確認を以下の2点に整理:
  - テストスイート全体がパスしているか（量的確認）
  - 実装準備フェーズ（ステップ3）でissueに記録された承認済みテスト計画の各項目が壊れていないか（質的確認）

## 結果

## 動作確認済み
- [ ] 