### PR TITLE
[minor] 三連複フォーメーション購入の追加

### DIFF
--- a/source/resources/js/components/presentational/TicketPurchaseForm/TicketPurchaseForm.stories.tsx
+++ b/source/resources/js/components/presentational/TicketPurchaseForm/TicketPurchaseForm.stories.tsx
@@ -132,3 +132,14 @@ export const SanrentanFormation: Story = {
 		selectedHorses: { col1: [1, 2], col2: [3, 4], col3: [5, 6, 7] },
 	},
 };
+
+// 三連複フォーメーションは着順不問のため「1列目/2列目/3列目」ラベルを使用（1着/2着/3着ではない）
+export const SanrenpukuFormation: Story = {
+	name: "三連複・フォーメーション（④着順別）",
+	args: {
+		...baseArgs,
+		selectedTicketTypeId: "sanrenpuku",
+		selectedBuyTypeId: "formation",
+		selectedHorses: { col1: [1, 2], col2: [3, 4], col3: [5, 6, 7] },
+	},
+};

--- a/source/resources/js/components/presentational/TicketPurchaseForm/TicketPurchaseForm.unit.test.tsx
+++ b/source/resources/js/components/presentational/TicketPurchaseForm/TicketPurchaseForm.unit.test.tsx
@@ -274,6 +274,73 @@ describe("TicketPurchaseForm", () => {
 			).toBeInTheDocument();
 		});
 
+		it("三連複（sanrenpuku）の買い方に「フォーメーション」ボタンが表示される", () => {
+			// Act
+			render(
+				<TicketPurchaseForm
+					{...baseProps}
+					selectedTicketTypeId="sanrenpuku"
+					selectedBuyTypeId="nagashi"
+					selectedAxisCount={1}
+					selectedHorses={{ axis: [], others: [] }}
+				/>,
+			);
+
+			// Assert
+			expect(
+				screen.getByRole("button", { name: "フォーメーション" }),
+			).toBeInTheDocument();
+		});
+
+		it("三連複（sanrenpuku）+ フォーメーション（formation）のとき「フォーメーション」ボタンが aria-pressed=true になる", () => {
+			// Act
+			render(
+				<TicketPurchaseForm
+					{...baseProps}
+					selectedTicketTypeId="sanrenpuku"
+					selectedBuyTypeId="formation"
+					selectedHorses={{ col1: [], col2: [], col3: [] }}
+				/>,
+			);
+
+			// Assert
+			expect(
+				screen.getByRole("button", { name: "フォーメーション" }),
+			).toHaveAttribute("aria-pressed", "true");
+		});
+
+		it("三連複（sanrenpuku）+ フォーメーション（formation）のとき「1列目」「2列目」「3列目」ラベルが表示される", () => {
+			// Act
+			render(
+				<TicketPurchaseForm
+					{...baseProps}
+					selectedTicketTypeId="sanrenpuku"
+					selectedBuyTypeId="formation"
+					selectedHorses={{ col1: [], col2: [], col3: [] }}
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByText("1列目")).toBeInTheDocument();
+			expect(screen.getByText("2列目")).toBeInTheDocument();
+			expect(screen.getByText("3列目")).toBeInTheDocument();
+		});
+
+		it("三連複（sanrenpuku）+ フォーメーション（formation）のとき「軸の頭数」セレクタが表示されない", () => {
+			// Act
+			render(
+				<TicketPurchaseForm
+					{...baseProps}
+					selectedTicketTypeId="sanrenpuku"
+					selectedBuyTypeId="formation"
+					selectedHorses={{ col1: [], col2: [], col3: [] }}
+				/>,
+			);
+
+			// Assert
+			expect(screen.queryByText("軸の頭数")).not.toBeInTheDocument();
+		});
+
 		it("上記以外の組み合わせでは「軸の頭数」「流し方向」セレクタが表示されない", () => {
 			// Act
 			render(
@@ -339,5 +406,13 @@ describe("getHorseInputConfigKey", () => {
 
 		// Assert
 		expect(result).toBe("formation");
+	});
+
+	it("ticketTypeId が sanrenpuku かつ buyTypeId が formation のとき formation_sanrenpuku を返す", () => {
+		// Act
+		const result = getHorseInputConfigKey("sanrenpuku", "formation", 1, 1);
+
+		// Assert
+		expect(result).toBe("formation_sanrenpuku");
 	});
 });

--- a/source/resources/js/components/presentational/TicketPurchaseForm/constants.ts
+++ b/source/resources/js/components/presentational/TicketPurchaseForm/constants.ts
@@ -50,6 +50,7 @@ export const BUY_TYPE_MAP: Record<
 	sanrenpuku: [
 		{ id: "nagashi", label: "流し" },
 		{ id: "box", label: "ボックス" },
+		{ id: "formation", label: "フォーメーション" },
 	],
 	sanrentan: [
 		{ id: "nagashi", label: "流し" },
@@ -79,10 +80,16 @@ export const HORSE_INPUT_CONFIG: Record<
 		{ key: "axis2", label: "軸2" },
 		{ key: "others", label: "相手" },
 	],
-	// 三連単流し・全券種フォーメーション（パターン④）
+	// 三連単流し・三連単フォーメーション（パターン④）
 	formation: [
 		{ key: "col1", label: "1着" },
 		{ key: "col2", label: "2着" },
 		{ key: "col3", label: "3着" },
+	],
+	// 三連複フォーメーション（着順不問のため「列」ラベル）
+	formation_sanrenpuku: [
+		{ key: "col1", label: "1列目" },
+		{ key: "col2", label: "2列目" },
+		{ key: "col3", label: "3列目" },
 	],
 };

--- a/source/resources/js/components/presentational/TicketPurchaseForm/utils.ts
+++ b/source/resources/js/components/presentational/TicketPurchaseForm/utils.ts
@@ -14,5 +14,8 @@ export function getHorseInputConfigKey(
 			? "formation"
 			: `nagashi_axis${axisCount}`;
 	}
+	if (buyTypeId === "formation" && ticketTypeId === "sanrenpuku") {
+		return "formation_sanrenpuku";
+	}
 	return buyTypeId;
 }


### PR DESCRIPTION
## やったこと

- 馬券登録画面（/tickets/new）の三連複（sanrenpuku）に「フォーメーション」買い方を追加
- 三連複フォーメーションの馬番入力グループのラベルを「1列目/2列目/3列目」に設定（三連単の「1着/2着/3着」とは区別）
- `HORSE_INPUT_CONFIG` に `formation_sanrenpuku` キーを新設し、`getHorseInputConfigKey` で三連複+フォーメーション時に返すよう分岐を追加

## 結果

## 動作確認済み

- [ ] 三連複を選択すると「フォーメーション」ボタンが表示される
- [ ] 「フォーメーション」を選択すると「1列目」「2列目」「3列目」のグリッドが表示される
- [ ] 「フォーメーション」選択時に「軸の頭数」セレクターが表示されない
- [ ] 馬番を選択して登録できる