### PR TITLE
[patch] ダッシュボードの購入金額を合計金額（単価×有効点数）で表示する

### DIFF
--- a/source/app/UseCases/Balance/ShowDashboardAction.php
+++ b/source/app/UseCases/Balance/ShowDashboardAction.php
@@ -2,13 +2,21 @@
 
 namespace App\UseCases\Balance;
 
+use App\UseCases\TicketPurchase\ExpandSelectionsAction;
 use Illuminate\Support\Facades\DB;
 
 /**
  * 収支ダッシュボードに表示する年間サマリー・日次収支・年一覧を集計して返す。
+ *
+ * 購入金額は「単価 × 有効点数」で算出する。有効点数は selections を
+ * ExpandSelectionsAction で展開した結果の件数。
  */
 class ShowDashboardAction
 {
+    public function __construct(
+        private ExpandSelectionsAction $expandSelections,
+    ) {}
+
     /**
      * @return array{
      *   selected_year: int,
@@ -43,33 +51,62 @@ class ShowDashboardAction
             ->values()
             ->all();
 
-        $dailyRows = DB::table('ticket_purchases')
+        $purchaseRows = DB::table('ticket_purchases')
             ->join('races', 'ticket_purchases.race_id', '=', 'races.id')
+            ->join('ticket_types', 'ticket_purchases.ticket_type_id', '=', 'ticket_types.id')
+            ->join('buy_types', 'ticket_purchases.buy_type_id', '=', 'buy_types.id')
             ->where('ticket_purchases.user_id', $userId)
             ->whereRaw('YEAR(races.race_date) = ?', [$selectedYear])
-            ->groupBy('races.race_date')
             ->orderBy('races.race_date')
             ->selectRaw('DATE_FORMAT(races.race_date, "%Y-%m-%d") as date')
-            ->selectRaw('SUM(COALESCE(ticket_purchases.amount, 0)) as purchase_amount')
-            ->selectRaw('SUM(COALESCE(ticket_purchases.payout_amount, 0)) as payout_amount')
+            ->selectRaw('ticket_purchases.amount as amount')
+            ->selectRaw('COALESCE(ticket_purchases.payout_amount, 0) as payout_amount')
+            ->selectRaw('ticket_purchases.selections as selections')
+            ->selectRaw('ticket_types.name as ticket_type_name')
+            ->selectRaw('buy_types.name as buy_type_name')
             ->get();
 
-        $dailyBalances = $dailyRows->map(function ($row) {
-            $purchaseAmount = (int) $row->purchase_amount;
-            $payoutAmount = (int) $row->payout_amount;
+        /** @var array<string, array{purchase_amount: int, payout_amount: int}> $dailyMap */
+        $dailyMap = [];
+        foreach ($purchaseRows as $row) {
+            $date = (string) $row->date;
+            $selections = json_decode((string) $row->selections, true);
+
+            $purchaseAmount = $row->amount !== null
+                ? (int) $row->amount * count($this->expandSelections->execute(
+                    (string) $row->ticket_type_name,
+                    (string) $row->buy_type_name,
+                    is_array($selections) ? $selections : null,
+                ))
+                : 0;
+
+            if (! isset($dailyMap[$date])) {
+                $dailyMap[$date] = ['purchase_amount' => 0, 'payout_amount' => 0];
+            }
+
+            $dailyMap[$date]['purchase_amount'] += $purchaseAmount;
+            $dailyMap[$date]['payout_amount'] += (int) $row->payout_amount;
+        }
+
+        ksort($dailyMap);
+
+        $dailyBalances = [];
+        foreach ($dailyMap as $date => $amounts) {
+            $purchaseAmount = $amounts['purchase_amount'];
+            $payoutAmount = $amounts['payout_amount'];
             $netAmount = $payoutAmount - $purchaseAmount;
             $returnRate = $purchaseAmount > 0
                 ? round($payoutAmount / $purchaseAmount * 100, 1)
                 : 0.0;
 
-            return [
-                'date' => (string) $row->date,
+            $dailyBalances[] = [
+                'date' => $date,
                 'purchase_amount' => $purchaseAmount,
                 'payout_amount' => $payoutAmount,
                 'net_amount' => $netAmount,
                 'return_rate' => $returnRate,
             ];
-        })->values()->all();
+        }
 
         $summary = null;
         if (! empty($dailyBalances)) {

--- a/source/tests/Feature/DashboardTest.php
+++ b/source/tests/Feature/DashboardTest.php
@@ -323,3 +323,121 @@ test('payout_amount が null の馬券は 0 として集計される', function 
         ->where('daily_balances.0.net_amount', -1000)
     );
 });
+
+test('nagashi（流し）・2点の馬券: summary の total_purchase_amount が 単価×2 で返る', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $now = now();
+
+    $venueId = DB::table('venues')->insertGetId([
+        'name' => '東京',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $raceId = DB::table('races')->insertGetId([
+        'uid' => 'test-uid-'.uniqid(),
+        'venue_id' => $venueId,
+        'race_date' => '2026-04-05',
+        'race_number' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $ticketTypeId = DB::table('ticket_types')->insertGetId([
+        'name' => 'umaren',
+        'label' => '馬連',
+        'sort_order' => 4,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $buyTypeId = DB::table('buy_types')->insertGetId([
+        'name' => 'nagashi',
+        'label' => '流し',
+        'sort_order' => 2,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    DB::table('ticket_purchases')->insert([
+        'user_id' => $user->id,
+        'race_id' => $raceId,
+        'ticket_type_id' => $ticketTypeId,
+        'buy_type_id' => $buyTypeId,
+        'selections' => json_encode(['axis' => [1], 'others' => [2, 3]]),
+        'amount' => 200,
+        'payout_amount' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('dashboard', ['year' => 2026]));
+
+    // Assert
+    $response->assertInertia(fn ($page) => $page
+        ->component('dashboard')
+        ->where('summary.total_purchase_amount', 400)
+        ->where('daily_balances.0.purchase_amount', 400)
+    );
+});
+
+test('amount が null の馬券は purchase_amount が 0 として集計される', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $now = now();
+
+    $venueId = DB::table('venues')->insertGetId([
+        'name' => '東京',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $raceId = DB::table('races')->insertGetId([
+        'uid' => 'test-uid-'.uniqid(),
+        'venue_id' => $venueId,
+        'race_date' => '2026-04-05',
+        'race_number' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $ticketTypeId = DB::table('ticket_types')->insertGetId([
+        'name' => 'tansho',
+        'label' => '単勝',
+        'sort_order' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $buyTypeId = DB::table('buy_types')->insertGetId([
+        'name' => 'single',
+        'label' => '通常',
+        'sort_order' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    DB::table('ticket_purchases')->insert([
+        'user_id' => $user->id,
+        'race_id' => $raceId,
+        'ticket_type_id' => $ticketTypeId,
+        'buy_type_id' => $buyTypeId,
+        'selections' => json_encode(['horses' => [1]]),
+        'amount' => null,
+        'payout_amount' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('dashboard', ['year' => 2026]));
+
+    // Assert
+    $response->assertInertia(fn ($page) => $page
+        ->component('dashboard')
+        ->where('daily_balances.0.purchase_amount', 0)
+        ->where('summary.total_purchase_amount', 0)
+    );
+});


### PR DESCRIPTION
## やったこと

- ダッシュボードの年間サマリー・日次収支の購入金額計算を `SUM(amount)` から「単価 × 有効点数」の合計に修正
- PR #123 の購入馬券一覧と同じ `ExpandSelectionsAction` を使用した計算ロジックに統一
- `ShowDashboardAction` に `ExpandSelectionsAction` を DI で注入し、レコードごとに `単価 × count(展開結果)` を計算するように変更
- 仕様守護テストを追加（nagashi 流し 2点のケース、amount null のケース）

## 結果

テスト `DashboardTest` 12件 全パス

## 動作確認済み

- [ ] 複数点買い（nagashi / box / formation）の馬券を含むデータで、年間サマリー・日次収支の購入金額が「単価×有効点数」の合計になっていることを確認