### PR TITLE
[patch] 単複（tanpuku）のダッシュボード購入金額集計に対応する

### DIFF
--- a/source/app/UseCases/TicketPurchase/ExpandSelectionsAction.php
+++ b/source/app/UseCases/TicketPurchase/ExpandSelectionsAction.php
@@ -23,6 +23,7 @@ class ExpandSelectionsAction
         'wide' => 2,
         'sanrenpuku' => 3,
         'sanrentan' => 3,
+        'tanpuku' => 2,
     ];
 
     /**
@@ -37,6 +38,14 @@ class ExpandSelectionsAction
         $horseCount = self::TICKET_TYPE_HORSE_COUNT[$ticketTypeName] ?? null;
         if ($horseCount === null) {
             return [];
+        }
+
+        // tanpuku は1馬選択で単勝+複勝の2点同時購入として扱う（normalize による重複排除を避けるため、展開ロジックを分岐させる）
+        if ($ticketTypeName === 'tanpuku') {
+            $horses = $this->extractIntList(($selections ?? [])['horses'] ?? []);
+            $singles = array_map(static fn (int $h): array => [$h], $horses);
+
+            return array_merge($singles, $singles);
         }
 
         $isOrdered = in_array($ticketTypeName, self::ORDERED_TYPES, true);

--- a/source/tests/Feature/DashboardTest.php
+++ b/source/tests/Feature/DashboardTest.php
@@ -383,6 +383,122 @@ test('nagashi（流し）・2点の馬券: summary の total_purchase_amount が
     );
 });
 
+test('単複（tanpuku）の馬券: summary の total_purchase_amount が 単価×2 で返る', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $now = now();
+
+    $venueId = DB::table('venues')->insertGetId([
+        'name' => '東京',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $raceId = DB::table('races')->insertGetId([
+        'uid' => 'test-uid-'.uniqid(),
+        'venue_id' => $venueId,
+        'race_date' => '2026-04-05',
+        'race_number' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $ticketTypeId = DB::table('ticket_types')->insertGetId([
+        'name' => 'tanpuku',
+        'label' => '単複',
+        'sort_order' => 9,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $buyTypeId = DB::table('buy_types')->insertGetId([
+        'name' => 'single',
+        'label' => '通常',
+        'sort_order' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    DB::table('ticket_purchases')->insert([
+        'user_id' => $user->id,
+        'race_id' => $raceId,
+        'ticket_type_id' => $ticketTypeId,
+        'buy_type_id' => $buyTypeId,
+        'selections' => json_encode(['horses' => [1]]),
+        'amount' => 200,
+        'payout_amount' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('dashboard', ['year' => 2026]));
+
+    // Assert
+    $response->assertInertia(fn ($page) => $page
+        ->component('dashboard')
+        ->where('summary.total_purchase_amount', 400)
+    );
+});
+
+test('単複（tanpuku）の馬券: daily_balances の purchase_amount が 単価×2 で返る', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $now = now();
+
+    $venueId = DB::table('venues')->insertGetId([
+        'name' => '東京',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $raceId = DB::table('races')->insertGetId([
+        'uid' => 'test-uid-'.uniqid(),
+        'venue_id' => $venueId,
+        'race_date' => '2026-04-05',
+        'race_number' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $ticketTypeId = DB::table('ticket_types')->insertGetId([
+        'name' => 'tanpuku',
+        'label' => '単複',
+        'sort_order' => 9,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $buyTypeId = DB::table('buy_types')->insertGetId([
+        'name' => 'single',
+        'label' => '通常',
+        'sort_order' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    DB::table('ticket_purchases')->insert([
+        'user_id' => $user->id,
+        'race_id' => $raceId,
+        'ticket_type_id' => $ticketTypeId,
+        'buy_type_id' => $buyTypeId,
+        'selections' => json_encode(['horses' => [1]]),
+        'amount' => 200,
+        'payout_amount' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('dashboard', ['year' => 2026]));
+
+    // Assert
+    $response->assertInertia(fn ($page) => $page
+        ->component('dashboard')
+        ->where('daily_balances.0.purchase_amount', 400)
+    );
+});
+
 test('amount が null の馬券は purchase_amount が 0 として集計される', function () {
     // Arrange
     $user = User::factory()->create();


### PR DESCRIPTION
## やったこと

- `ExpandSelectionsAction::TICKET_TYPE_HORSE_COUNT` に `'tanpuku' => 2` を追加
- `execute()` に tanpuku の特殊分岐を追加（単勝+複勝の2点同時購入として1馬選択から2組み合わせを返す）
- `DashboardTest` に単複の購入金額集計テストを2件追加（`summary.total_purchase_amount` と `daily_balances.purchase_amount` がそれぞれ単価×2になること）

## 結果

<\!-- スクリーンショット・動画を添付する -->

## 動作確認済み

- [ ] 単複の馬券を購入し、ダッシュボードの購入金額に単価×2が反映されること