### PR TITLE
[minor] git worktree管理スクリプトの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.worktree-registry

--- a/README.md
+++ b/README.md
@@ -43,3 +43,49 @@ pnpm format
 ```bash
 php artisan app:create-user
 ```
+
+## git worktree を使った並列開発
+
+Claude Code エージェントで複数 issue を並列実装する際に使用する。
+
+### worktree 作成
+
+```bash
+# プロジェクトルートから実行
+# ./scripts/wt-new.sh <issue番号> <ブランチ名>
+./scripts/wt-new.sh 130 feat/my-feature
+```
+
+`../keiba-db-gen2-wt/issue-130/` に worktree が作成され、以下が自動実行される:
+- `composer install`（使い捨てコンテナ経由）
+- `pnpm install`
+- `.env` のコピーとポート・DB 名の自動割り当て
+
+### worktree 内での開発
+
+```bash
+cd ../keiba-db-gen2-wt/issue-130/source
+
+# コンテナ起動
+./vendor/bin/sail up -d
+
+# マイグレーション
+./vendor/bin/sail artisan migrate
+
+# テスト（worktree 独立の DB を使用）
+DB_DATABASE=testing_wt1 ./vendor/bin/sail artisan test
+```
+
+### worktree 削除
+
+```bash
+./scripts/wt-rm.sh 130
+```
+
+### ポート割り当て
+
+| オフセット | APP_PORT | VITE_PORT | FORWARD_DB_PORT | DB_DATABASE |
+|----------|----------|-----------|----------------|-------------|
+| main     | 80       | 5173      | 3306           | （.env の値） |
+| 1        | 8001     | 5174      | 3307           | keiba_wt1   |
+| 2        | 8002     | 5175      | 3308           | keiba_wt2   |

--- a/README.md
+++ b/README.md
@@ -10,21 +10,50 @@ https://github.com/nakajima97/ai-driven-development
 docs配下を確認
 
 ## セットアップ
+
+### 初回のみ
+
 ~~~bash
 # 移動（のちに記載したコマンドの前提条件）
 cd ./source
 
-# 初回のみ: Docker イメージのビルド
+# .env を作成
+cp .env.example .env
+
+# vendor/ をインストール（使い捨てコンテナ経由）
+docker run --rm \
+    -u "$(id -u):$(id -g)" \
+    -v "$(pwd):/var/www/html" \
+    -w /var/www/html \
+    laravelsail/php85-composer:latest \
+    composer install --ignore-platform-reqs
+
+# Docker イメージのビルド
 ./vendor/bin/sail build --no-cache
 
 # コンテナ起動
 ./vendor/bin/sail up -d
+
+# アプリケーションキーの生成
+./vendor/bin/sail artisan key:generate
 
 # マイグレーション
 ./vendor/bin/sail artisan migrate
 
 # シード
 ./vendor/bin/sail artisan db:seed
+
+# フロント依存関係のインストール
+pnpm install
+~~~
+
+### 通常起動
+
+~~~bash
+cd ./source
+
+# コンテナ起動
+./vendor/bin/sail up -d
 
 # フロント
 pnpm dev

--- a/scripts/wt-new.sh
+++ b/scripts/wt-new.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REGISTRY="${PROJECT_ROOT}/.worktree-registry"
+WORKTREE_BASE="$(cd "${PROJECT_ROOT}/.." && pwd)/keiba-db-gen2-wt"
+MAIN_SOURCE="${PROJECT_ROOT}/source"
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <issue-num> <branch-name>" >&2
+  exit 1
+fi
+
+ISSUE_NUM="$1"
+BRANCH_NAME="$2"
+
+if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+  echo "Error: issue-num must be a positive integer" >&2
+  exit 1
+fi
+
+if ! [[ "$BRANCH_NAME" =~ ^[a-zA-Z0-9/_-]+$ ]]; then
+  echo "Error: branch-name contains invalid characters" >&2
+  exit 1
+fi
+
+if [[ -f "$REGISTRY" ]] && grep -qE "^${ISSUE_NUM} " "$REGISTRY"; then
+  echo "Error: issue ${ISSUE_NUM} already exists in registry" >&2
+  exit 1
+fi
+
+get_next_offset() {
+  if [[ ! -f "$REGISTRY" ]]; then
+    echo 1
+    return
+  fi
+  local used_offsets
+  used_offsets=$(grep -vE '^\s*#|^\s*$' "$REGISTRY" | awk '{print $2}' | sort -n)
+  local candidate=1
+  while echo "$used_offsets" | grep -q "^${candidate}$"; do
+    candidate=$((candidate + 1))
+  done
+  echo "$candidate"
+}
+
+OFFSET=$(get_next_offset)
+WORKTREE_PATH="${WORKTREE_BASE}/issue-${ISSUE_NUM}"
+WT_SOURCE="${WORKTREE_PATH}/source"
+
+echo "==> Creating worktree: issue-${ISSUE_NUM} (offset=${OFFSET})"
+echo "    Path   : ${WORKTREE_PATH}"
+echo "    Branch : ${BRANCH_NAME}"
+
+mkdir -p "${WORKTREE_BASE}"
+
+git -C "${PROJECT_ROOT}" worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}"
+
+echo "==> Installing PHP dependencies via disposable container..."
+docker run --rm \
+  -u "$(id -u):$(id -g)" \
+  -v "${WT_SOURCE}:/var/www/html" \
+  -w /var/www/html \
+  laravelsail/php85-composer:latest \
+  composer install --ignore-platform-reqs
+
+echo "==> Installing Node dependencies..."
+(cd "${WT_SOURCE}" && pnpm install --frozen-lockfile)
+
+echo "==> Configuring .env..."
+cp "${MAIN_SOURCE}/.env" "${WT_SOURCE}/.env"
+
+APP_PORT="800${OFFSET}"
+VITE_PORT="$((5173 + OFFSET))"
+DB_PORT="$((3306 + OFFSET))"
+DB_DATABASE="keiba_wt${OFFSET}"
+COMPOSE_PROJECT_NAME="sail-wt-${OFFSET}"
+
+replace_or_append() {
+  local key="$1"
+  local value="$2"
+  local file="$3"
+  if grep -qE "^${key}=" "$file"; then
+    sed -i "s|^${key}=.*|${key}=${value}|" "$file"
+  else
+    echo "${key}=${value}" >> "$file"
+  fi
+}
+
+replace_or_append "COMPOSE_PROJECT_NAME" "${COMPOSE_PROJECT_NAME}" "${WT_SOURCE}/.env"
+replace_or_append "APP_PORT"             "${APP_PORT}"             "${WT_SOURCE}/.env"
+replace_or_append "VITE_PORT"            "${VITE_PORT}"            "${WT_SOURCE}/.env"
+replace_or_append "FORWARD_DB_PORT"      "${DB_PORT}"              "${WT_SOURCE}/.env"
+replace_or_append "DB_DATABASE"          "${DB_DATABASE}"          "${WT_SOURCE}/.env"
+
+if [[ ! -f "$REGISTRY" ]]; then
+  echo "# issue_num offset worktree_path" > "$REGISTRY"
+fi
+echo "${ISSUE_NUM} ${OFFSET} ${WORKTREE_PATH}" >> "$REGISTRY"
+
+echo ""
+echo "======================================================"
+echo " Worktree created successfully!"
+echo "======================================================"
+echo " Issue     : #${ISSUE_NUM}"
+echo " Branch    : ${BRANCH_NAME}"
+echo " Path      : ${WORKTREE_PATH}"
+echo " APP_PORT  : ${APP_PORT}  =>  http://localhost:${APP_PORT}"
+echo " VITE_PORT : ${VITE_PORT}"
+echo " DB_PORT   : ${DB_PORT}"
+echo " DB        : ${DB_DATABASE}"
+echo ""
+echo " Next steps:"
+echo "   cd ${WT_SOURCE}"
+echo "   ./vendor/bin/sail up -d"
+echo "   ./vendor/bin/sail artisan migrate"
+echo ""
+echo " Run tests:"
+echo "   DB_DATABASE=testing_wt${OFFSET} ./vendor/bin/sail artisan test"
+echo "======================================================"

--- a/scripts/wt-rm.sh
+++ b/scripts/wt-rm.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REGISTRY="${PROJECT_ROOT}/.worktree-registry"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <issue-num>" >&2
+  exit 1
+fi
+
+ISSUE_NUM="$1"
+
+if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+  echo "Error: issue-num must be a positive integer" >&2
+  exit 1
+fi
+
+if [[ ! -f "$REGISTRY" ]]; then
+  echo "Error: .worktree-registry not found at ${REGISTRY}" >&2
+  exit 1
+fi
+
+REGISTRY_LINE=$(grep -E "^${ISSUE_NUM} " "$REGISTRY" || true)
+if [[ -z "$REGISTRY_LINE" ]]; then
+  echo "Error: issue ${ISSUE_NUM} not found in registry" >&2
+  exit 1
+fi
+
+OFFSET=$(echo "$REGISTRY_LINE" | awk '{print $2}')
+WORKTREE_PATH=$(echo "$REGISTRY_LINE" | awk '{print $3}')
+WT_SOURCE="${WORKTREE_PATH}/source"
+
+echo "==> Removing worktree: issue-${ISSUE_NUM}"
+echo "    Path   : ${WORKTREE_PATH}"
+echo "    Offset : ${OFFSET}"
+
+if [[ -f "${WT_SOURCE}/vendor/bin/sail" && -f "${WT_SOURCE}/.env" ]]; then
+  echo "==> Stopping Docker containers..."
+  (cd "${WT_SOURCE}" && ./vendor/bin/sail down 2>/dev/null || true)
+else
+  echo "    Skipping sail down (sail or .env not found)"
+fi
+
+echo "==> Removing git worktree..."
+if ! git -C "${PROJECT_ROOT}" worktree remove "${WORKTREE_PATH}" 2>/dev/null; then
+  echo ""
+  echo "Warning: worktree has uncommitted changes."
+  read -r -p "Force remove? [y/N]: " confirm
+  if [[ "$confirm" =~ ^[Yy]$ ]]; then
+    git -C "${PROJECT_ROOT}" worktree remove --force "${WORKTREE_PATH}"
+  else
+    echo "Aborted."
+    exit 1
+  fi
+fi
+
+echo "==> Updating registry..."
+TMP_REGISTRY=$(mktemp)
+grep -vE "^${ISSUE_NUM} " "$REGISTRY" > "$TMP_REGISTRY"
+mv "$TMP_REGISTRY" "$REGISTRY"
+
+echo ""
+echo "======================================================"
+echo " Worktree removed successfully!"
+echo "======================================================"
+echo " Issue : #${ISSUE_NUM}"
+echo " Path  : ${WORKTREE_PATH}"
+echo ""
+echo " MySQL volume may remain. To remove:"
+echo "   docker volume rm sail-wt-${OFFSET}_sail-mysql"
+echo "======================================================"


### PR DESCRIPTION
## やったこと

- Claude Code エージェントで複数 issue を並列実装するための git worktree 管理スクリプトを追加
- `scripts/wt-new.sh`: worktree 作成（使い捨てコンテナで `composer install`、ポート・DB 自動割り当て）
- `scripts/wt-rm.sh`: worktree 削除（コンテナ停止・レジストリ更新）
- ルート `.gitignore` を新規作成し `.worktree-registry` を除外
- `README.md` に並列開発セクションを追記

## 結果

各 worktree に独立した Docker スタック・ポート・DB が割り当てられ、並列テスト実行時の競合を防ぐ。

| オフセット | APP_PORT | VITE_PORT | FORWARD_DB_PORT | DB_DATABASE |
|----------|----------|-----------|----------------|-------------|
| main     | 80       | 5173      | 3306           | （.env の値） |
| 1        | 8001     | 5174      | 3307           | keiba_wt1   |
| 2        | 8002     | 5175      | 3308           | keiba_wt2   |

## 動作確認済み

- [ ] `bash -n` による構文チェック通過済み