### PR TITLE
[patch] wt-new.sh の Docker イメージを php85 から php84 に修正する

### DIFF
--- a/scripts/wt-new.sh
+++ b/scripts/wt-new.sh
@@ -61,7 +61,7 @@ docker run --rm \
   -u "$(id -u):$(id -g)" \
   -v "${WT_SOURCE}:/var/www/html" \
   -w /var/www/html \
-  laravelsail/php85-composer:latest \
+  laravelsail/php84-composer:latest \
   composer install --ignore-platform-reqs
 
 echo "==> Installing Node dependencies..."


### PR DESCRIPTION
## やったこと

- `scripts/wt-new.sh` で指定していた `laravelsail/php85-composer:latest` を `laravelsail/php84-composer:latest` に変更した
- PHP 8.5 は未リリースのため Docker Hub にイメージが存在せず、worktree 作成時に docker pull が失敗していた

## 結果

特になし（スクリプトの1行修正のみ）

## 動作確認済み

- [ ] `./scripts/wt-new.sh <issue番号> <ブランチ名>` を実行して composer install が正常に完了すること