### PR TITLE
[minor] wt-new.sh に gh issue develop を組み込んでブランチと GitHub issue を紐づける

### DIFF
--- a/scripts/wt-new.sh
+++ b/scripts/wt-new.sh
@@ -48,13 +48,29 @@ OFFSET=$(get_next_offset)
 WORKTREE_PATH="${WORKTREE_BASE}/issue-${ISSUE_NUM}"
 WT_SOURCE="${WORKTREE_PATH}/source"
 
+if [[ -e "${WORKTREE_PATH}" ]]; then
+  echo "Error: worktree path already exists: ${WORKTREE_PATH}" >&2
+  exit 1
+fi
+
 echo "==> Creating worktree: issue-${ISSUE_NUM} (offset=${OFFSET})"
 echo "    Path   : ${WORKTREE_PATH}"
 echo "    Branch : ${BRANCH_NAME}"
 
 mkdir -p "${WORKTREE_BASE}"
 
-git -C "${PROJECT_ROOT}" worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}"
+if git -C "${PROJECT_ROOT}" show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"; then
+  echo "==> Branch '${BRANCH_NAME}' already exists locally, using it as-is"
+elif git -C "${PROJECT_ROOT}" ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
+  echo "==> Branch '${BRANCH_NAME}' exists on remote, fetching..."
+  git -C "${PROJECT_ROOT}" fetch origin "${BRANCH_NAME}"
+else
+  echo "==> Creating branch via 'gh issue develop' (linked to issue #${ISSUE_NUM})"
+  gh issue develop "${ISSUE_NUM}" --name "${BRANCH_NAME}" --base main
+  git -C "${PROJECT_ROOT}" fetch origin "${BRANCH_NAME}"
+fi
+
+git -C "${PROJECT_ROOT}" worktree add "${WORKTREE_PATH}" "${BRANCH_NAME}"
 
 echo "==> Installing PHP dependencies via disposable container..."
 docker run --rm \


### PR DESCRIPTION
## やったこと

- `wt-new.sh` に `gh issue develop` を組み込み、ブランチ作成と GitHub issue の紐づけを自動化した
- ブランチの存在状態（ローカル・リモート・未作成）に応じて分岐する処理を追加した
- worktree パスが既存の場合に早期エラーで停止するチェックを追加した

## 結果

ブランチの状態に応じた動作:

| 状態 | 動作 |
|------|------|
| ローカルに存在 | そのまま `git worktree add` |
| リモートのみ存在 | `git fetch` して `git worktree add` |
| どちらにも存在しない | `gh issue develop` でブランチ作成・issue 紐づけ → `git fetch` → `git worktree add` |
| worktree パスが既存 | エラーで即停止 |

## 動作確認済み

- [x] 新規 issue + ブランチ未作成で実行し、issue サイドバーの「Development」にブランチが表示されること
- [x] 事前にブランチを作成済みの状態で実行し、エラーなく worktree が作成されること
- [x] worktree パスが既存の状態で実行し、エラーメッセージで停止すること