### PR TITLE
[patch] wt-new.sh の VITE_PORT を 6000 番台に変更してポート衝突を回避する

### DIFF
--- a/scripts/wt-new.sh
+++ b/scripts/wt-new.sh
@@ -87,7 +87,7 @@ echo "==> Configuring .env..."
 cp "${MAIN_SOURCE}/.env" "${WT_SOURCE}/.env"
 
 APP_PORT="800${OFFSET}"
-VITE_PORT="$((5173 + OFFSET))"
+VITE_PORT="$((6000 + OFFSET))"
 DB_PORT="$((3306 + OFFSET))"
 DB_DATABASE="keiba_wt${OFFSET}"
 COMPOSE_PROJECT_NAME="sail-wt-${OFFSET}"


### PR DESCRIPTION
## やったこと

- worktree 作成スクリプト `wt-new.sh` の VITE_PORT 計算を `5173 + OFFSET` から `6000 + OFFSET` に変更
- メインプロジェクトのデフォルト Vite ポート（5173）との衝突を回避

## 結果

特になし（スクリプト修正のみ）

## 動作確認済み

- [ ] 