### PR TITLE
[patch] vite.config.ts で loadEnv を使って VITE_PORT を明示的に読み込む

### DIFF
--- a/source/vite.config.ts
+++ b/source/vite.config.ts
@@ -3,26 +3,34 @@ import { wayfinder } from '@laravel/vite-plugin-wayfinder';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import laravel from 'laravel-vite-plugin';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
 const isCI = process.env.CI === 'true';
 
-export default defineConfig({
-    plugins: [
-        laravel({
-            input: ['resources/css/app.css', 'resources/js/app.tsx'],
-            refresh: true,
-        }),
-        inertia(),
-        react({
-            babel: {
-                plugins: ['babel-plugin-react-compiler'],
-            },
-        }),
-        tailwindcss(),
-        !isCI && !process.env.STORYBOOK && wayfinder({
-            formVariants: true,
-            command: './vendor/bin/sail artisan wayfinder:generate --with-form',
-        }),
-    ],
+export default defineConfig(({ mode }) => {
+    const env = loadEnv(mode, process.cwd(), '');
+    const port = parseInt(env.VITE_PORT || '5173', 10);
+
+    return {
+        server: {
+            port,
+        },
+        plugins: [
+            laravel({
+                input: ['resources/css/app.css', 'resources/js/app.tsx'],
+                refresh: true,
+            }),
+            inertia(),
+            react({
+                babel: {
+                    plugins: ['babel-plugin-react-compiler'],
+                },
+            }),
+            tailwindcss(),
+            !isCI && !process.env.STORYBOOK && wayfinder({
+                formVariants: true,
+                command: './vendor/bin/sail artisan wayfinder:generate --with-form',
+            }),
+        ],
+    };
 });


### PR DESCRIPTION
## やったこと

- `vite.config.ts` で `loadEnv` を使って `.env` の `VITE_PORT` を明示的に読み込み `server.port` に反映するよう修正
- `wt-new.sh` の `VITE_PORT` 割り当てを `5173 + OFFSET` から `6000 + OFFSET` に変更し、Vite デフォルトポート（5173）との衝突を回避

## 結果

## 動作確認済み

- [ ] worktree で `pnpm dev` を実行したとき `.env` の `VITE_PORT` が反映されること