### PR TITLE
[patch] pnpm storybook が .env の STORYBOOK_PORT を読み込まず 6006 で起動する問題を修正

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -13,7 +13,7 @@
         "check": "biome check --write resources/",
         "tc": "tsc --noEmit",
         "test": "vitest",
-        "storybook": "storybook dev -p ${STORYBOOK_PORT:-6006} --no-open",
+        "storybook": "storybook dev -p $(grep -E '^STORYBOOK_PORT=' .env | cut -d= -f2 || echo 6006) --no-open",
         "build-storybook": "storybook build"
     },
     "devDependencies": {


### PR DESCRIPTION
## やったこと

- `package.json` の storybook スクリプトで `.env` の `STORYBOOK_PORT` が反映されない問題を修正
- `${STORYBOOK_PORT:-6006}` はシェル環境変数しか参照しないが `.env` はシェルに自動読み込みされないため、常にデフォルト値 6006 で起動していた
- `$(grep -E '^STORYBOOK_PORT=' .env | cut -d= -f2 || echo 6006)` に変更し、`.env` から直接値を取得して `-p` に渡すよう修正

## 結果

## 動作確認済み

- [ ] `wt-new.sh` で作成したワークツリーで `pnpm storybook` を実行すると `.env` の `STORYBOOK_PORT` のポートで起動することを確認