### PR TITLE
[patch] settings.jsonのDenyルールを修正し.envの読み込みとgrepバイパスを防止する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,9 +15,11 @@
     ],
     "deny": [
       "Bash(curl *)",
-      "Read(./.env)",
-      "Read(./.env.*)",
-      "Read(./secrets/**)"
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(./secrets/**)",
+      "Bash(grep *.env)",
+      "Bash(grep *.env.*)"
     ]
   },
   "enabledPlugins": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,8 +9,14 @@
       "Bash(git push)",
       "Write(*.md)",
       "Write(.claude/skills/**)",
+      "Write(**/*.tsx)",
+      "Write(**/*.ts)",
+      "Write(**/*.php)",
       "Read(*.md)",
       "Edit(/.claude/skills/**)",
+      "Edit(**/*.tsx)",
+      "Edit(**/*.ts)",
+      "Edit(**/*.php)",
       "Bash(mkdir -p *)"
     ],
     "deny": [


### PR DESCRIPTION
## やったこと

- `Read(./.env)` / `Read(./.env.*)` を `Read(**/.env)` / `Read(**/.env.*)` に変更し、サブディレクトリ配下の `.env` ファイルも保護対象にした
- `Bash(grep *.env)` / `Bash(grep *.env.*)` を deny に追加し、grep コマンドによる `.env` 読み取りバイパスを防止した
- `Edit(**/*.tsx)` / `Edit(**/*.ts)` / `Edit(**/*.php)` および対応する `Write` ルールを allow に追加し、コードファイルの編集を明示的に許可した

## 結果

## 動作確認済み

- [ ] `source/.env` が Read ツールで読み込めないことを確認
- [ ] `grep "" source/.env` が Bash ツールで拒否されることを確認
- [ ] `.tsx` / `.php` ファイルの編集が引き続き許可されていることを確認