### PR TITLE
[minor] レース結果確認画面の実装

### DIFF
--- a/source/app/Http/Controllers/RaceResultController.php
+++ b/source/app/Http/Controllers/RaceResultController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\RaceResult\StoreRaceResultRequest;
 use App\UseCases\RaceResult\ShowAction;
+use App\UseCases\RaceResult\ShowResultAction;
 use App\UseCases\RaceResult\StoreAction;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
@@ -29,7 +30,7 @@ class RaceResultController extends Controller
         return redirect()->route('tickets.index');
     }
 
-    public function edit(string $uid, ShowAction $action): Response
+    public function edit(string $uid, ShowResultAction $action): Response
     {
         return Inertia::render('races/result/edit', [
             'race' => $action->execute($uid),

--- a/source/app/UseCases/RaceResult/ShowResultAction.php
+++ b/source/app/UseCases/RaceResult/ShowResultAction.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\UseCases\RaceResult;
+
+use App\Models\Race;
+
+/**
+ * uid でレースを取得し、レース結果確認・編集画面の表示用データ（払戻情報を含む）を返す。
+ */
+class ShowResultAction
+{
+    /**
+     * @return array{
+     *     uid: string,
+     *     venue_name: string,
+     *     race_date: string,
+     *     race_number: int,
+     *     payouts: list<array{
+     *         ticket_type_label: string,
+     *         ticket_type_name: string,
+     *         payout_amount: int,
+     *         popularity: int,
+     *         horses: list<array{horse_number: int, sort_order: int}>,
+     *     }>,
+     * }
+     */
+    public function execute(string $uid): array
+    {
+        $race = Race::where('uid', $uid)
+            ->with([
+                'venue',
+                'racePayouts' => function ($query) {
+                    $query->join('ticket_types', 'race_payouts.ticket_type_id', '=', 'ticket_types.id')
+                        ->orderBy('ticket_types.sort_order')
+                        ->select('race_payouts.*');
+                },
+                'racePayouts.ticketType',
+                'racePayouts.racePayoutHorses' => function ($query) {
+                    $query->orderBy('sort_order');
+                },
+            ])
+            ->firstOrFail();
+
+        $payouts = $race->racePayouts->map(function ($payout) {
+            return [
+                'ticket_type_label' => $payout->ticketType->label,
+                'ticket_type_name' => $payout->ticketType->name,
+                'payout_amount' => $payout->payout_amount,
+                'popularity' => $payout->popularity,
+                'horses' => $payout->racePayoutHorses->map(function ($horse) {
+                    return [
+                        'horse_number' => $horse->horse_number,
+                        'sort_order' => $horse->sort_order,
+                    ];
+                })->values()->all(),
+            ];
+        })->values()->all();
+
+        return [
+            'uid' => $race->uid,
+            'venue_name' => $race->venue->name,
+            'race_date' => $race->race_date,
+            'race_number' => $race->race_number,
+            'payouts' => $payouts,
+        ];
+    }
+}

--- a/source/resources/js/features/raceDetail/presentational/RaceDetail/index.tsx
+++ b/source/resources/js/features/raceDetail/presentational/RaceDetail/index.tsx
@@ -12,9 +12,7 @@ export default function RaceDetail({ race }: RaceDetailProps) {
 							<th className="w-32 bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
 								開催日
 							</th>
-							<td className="px-4 py-3">
-								{race.race_date.replace(/-/g, "/")}
-							</td>
+							<td className="px-4 py-3">{race.race_date.replace(/-/g, "/")}</td>
 						</tr>
 						<tr className="border-b">
 							<th className="bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
@@ -57,10 +55,7 @@ export default function RaceDetail({ race }: RaceDetailProps) {
 					</thead>
 					<tbody>
 						{race.entries.map((entry) => (
-							<tr
-								key={entry.horse_number}
-								className="border-b last:border-0"
-							>
+							<tr key={entry.horse_number} className="border-b last:border-0">
 								<td className="px-4 py-3">{entry.frame_number}</td>
 								<td className="px-4 py-3">{entry.horse_number}</td>
 								<td className="px-4 py-3">{entry.horse_name}</td>

--- a/source/resources/js/features/raceList/presentational/RaceList/index.tsx
+++ b/source/resources/js/features/raceList/presentational/RaceList/index.tsx
@@ -83,9 +83,7 @@ export default function RaceList({
 								<tr
 									key={race.uid}
 									className="cursor-pointer border-b last:border-0 hover:bg-muted/30"
-									onClick={() =>
-										router.visit(show.url({ race: race.uid }))
-									}
+									onClick={() => router.visit(show.url({ race: race.uid }))}
 									onKeyDown={(e) => {
 										if (e.key === "Enter" || e.key === " ") {
 											router.visit(show.url({ race: race.uid }));

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import RaceResultDetail from ".";
+import type { RaceResultDetailProps } from ".";
+
+const meta: Meta<typeof RaceResultDetail> = {
+	title: "features/raceResult/RaceResultDetail",
+	component: RaceResultDetail,
+};
+
+export default meta;
+type Story = StoryObj<typeof RaceResultDetail>;
+
+const baseRace: Pick<
+	RaceResultDetailProps["race"],
+	"uid" | "venue_name" | "race_date" | "race_number"
+> = {
+	uid: "abc001",
+	venue_name: "東京",
+	race_date: "2026-04-19",
+	race_number: 11,
+};
+
+const allPayouts: RaceResultDetailProps["race"]["payouts"] = [
+	{
+		ticket_type_label: "単勝",
+		ticket_type_name: "tansho",
+		payout_amount: 610,
+		popularity: 2,
+		horses: [{ horse_number: 3, sort_order: 1 }],
+	},
+	{
+		ticket_type_label: "複勝",
+		ticket_type_name: "fukusho",
+		payout_amount: 180,
+		popularity: 1,
+		horses: [{ horse_number: 3, sort_order: 1 }],
+	},
+	{
+		ticket_type_label: "複勝",
+		ticket_type_name: "fukusho",
+		payout_amount: 340,
+		popularity: 3,
+		horses: [{ horse_number: 5, sort_order: 1 }],
+	},
+	{
+		ticket_type_label: "複勝",
+		ticket_type_name: "fukusho",
+		payout_amount: 450,
+		popularity: 4,
+		horses: [{ horse_number: 8, sort_order: 1 }],
+	},
+	{
+		ticket_type_label: "枠連",
+		ticket_type_name: "wakuren",
+		payout_amount: 820,
+		popularity: 3,
+		horses: [
+			{ horse_number: 3, sort_order: 1 },
+			{ horse_number: 5, sort_order: 2 },
+		],
+	},
+	{
+		ticket_type_label: "馬連",
+		ticket_type_name: "umaren",
+		payout_amount: 1350,
+		popularity: 2,
+		horses: [
+			{ horse_number: 3, sort_order: 1 },
+			{ horse_number: 5, sort_order: 2 },
+		],
+	},
+	{
+		ticket_type_label: "馬単",
+		ticket_type_name: "umatan",
+		payout_amount: 2410,
+		popularity: 3,
+		horses: [
+			{ horse_number: 3, sort_order: 1 },
+			{ horse_number: 5, sort_order: 2 },
+		],
+	},
+	{
+		ticket_type_label: "ワイド",
+		ticket_type_name: "wide",
+		payout_amount: 340,
+		popularity: 2,
+		horses: [
+			{ horse_number: 3, sort_order: 1 },
+			{ horse_number: 5, sort_order: 2 },
+		],
+	},
+	{
+		ticket_type_label: "ワイド",
+		ticket_type_name: "wide",
+		payout_amount: 280,
+		popularity: 3,
+		horses: [
+			{ horse_number: 3, sort_order: 1 },
+			{ horse_number: 8, sort_order: 2 },
+		],
+	},
+	{
+		ticket_type_label: "ワイド",
+		ticket_type_name: "wide",
+		payout_amount: 440,
+		popularity: 5,
+		horses: [
+			{ horse_number: 5, sort_order: 1 },
+			{ horse_number: 8, sort_order: 2 },
+		],
+	},
+	{
+		ticket_type_label: "三連複",
+		ticket_type_name: "sanrenpuku",
+		payout_amount: 2150,
+		popularity: 4,
+		horses: [
+			{ horse_number: 3, sort_order: 1 },
+			{ horse_number: 5, sort_order: 2 },
+			{ horse_number: 8, sort_order: 3 },
+		],
+	},
+	{
+		ticket_type_label: "三連単",
+		ticket_type_name: "sanrentan",
+		payout_amount: 18000,
+		popularity: 12,
+		horses: [
+			{ horse_number: 3, sort_order: 1 },
+			{ horse_number: 5, sort_order: 2 },
+			{ horse_number: 8, sort_order: 3 },
+		],
+	},
+];
+
+export const Default: Story = {
+	name: "全券種表示",
+	args: {
+		race: {
+			...baseRace,
+			payouts: allPayouts,
+		},
+	},
+};
+
+export const ArrowNotation: Story = {
+	name: "馬単・三連単の矢印表記確認",
+	args: {
+		race: {
+			...baseRace,
+			payouts: [
+				{
+					ticket_type_label: "馬単",
+					ticket_type_name: "umatan",
+					payout_amount: 2410,
+					popularity: 3,
+					horses: [
+						{ horse_number: 3, sort_order: 1 },
+						{ horse_number: 5, sort_order: 2 },
+					],
+				},
+				{
+					ticket_type_label: "三連単",
+					ticket_type_name: "sanrentan",
+					payout_amount: 18000,
+					popularity: 12,
+					horses: [
+						{ horse_number: 3, sort_order: 1 },
+						{ horse_number: 5, sort_order: 2 },
+						{ horse_number: 8, sort_order: 3 },
+					],
+				},
+			],
+		},
+	},
+};

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -31,17 +31,14 @@ export default function RaceResultDetail({ race }: RaceResultDetailProps) {
 						</tr>
 					</thead>
 					<tbody>
-						{race.payouts.map((payout, index) => (
+						{race.payouts.map((payout) => (
 							<tr
-								key={index}
+								key={`${payout.ticket_type_name}-${payout.horses.map((h) => h.horse_number).join("-")}`}
 								className="border-b last:border-0 hover:bg-muted/30"
 							>
 								<td className="px-4 py-3">{payout.ticket_type_label}</td>
 								<td className="px-4 py-3">
-									{formatHorseNumbers(
-										payout.horses,
-										payout.ticket_type_name,
-									)}
+									{formatHorseNumbers(payout.horses, payout.ticket_type_name)}
 								</td>
 								<td className="px-4 py-3 text-right">
 									¥{payout.payout_amount.toLocaleString()}

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -1,0 +1,72 @@
+import type { RaceResultDetailProps } from "./types";
+
+const ARROW_TICKET_TYPES = ["umatan", "sanrentan"];
+
+function formatHorseNumbers(
+	horses: { horse_number: number; sort_order: number }[],
+	ticketTypeName: string,
+): string {
+	const sorted = [...horses].sort((a, b) => a.sort_order - b.sort_order);
+	const numbers = sorted.map((h) => h.horse_number);
+	const separator = ARROW_TICKET_TYPES.includes(ticketTypeName) ? "→" : "-";
+	return numbers.join(separator);
+}
+
+export default function RaceResultDetail({ race }: RaceResultDetailProps) {
+	return (
+		<div className="flex flex-col gap-4 p-4">
+			<div>
+				<h1 className="text-xl font-semibold">レース結果</h1>
+				<p className="text-sm text-muted-foreground">
+					{race.race_date.replace(/-/g, "/")} {race.venue_name}{" "}
+					{race.race_number}R
+				</p>
+			</div>
+
+			<div className="overflow-x-auto rounded-xl border">
+				<table className="w-full text-sm">
+					<thead>
+						<tr className="border-b bg-muted/50">
+							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+								券種
+							</th>
+							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+								馬番
+							</th>
+							<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+								払戻金額
+							</th>
+							<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+								人気
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{race.payouts.map((payout, index) => (
+							<tr
+								key={index}
+								className="border-b last:border-0 hover:bg-muted/30"
+							>
+								<td className="px-4 py-3">{payout.ticket_type_label}</td>
+								<td className="px-4 py-3">
+									{formatHorseNumbers(
+										payout.horses,
+										payout.ticket_type_name,
+									)}
+								</td>
+								<td className="px-4 py-3 text-right">
+									¥{payout.payout_amount.toLocaleString()}
+								</td>
+								<td className="px-4 py-3 text-right">
+									{payout.popularity}人気
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	);
+}
+
+export type { RaceResultDetailProps } from "./types";

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -1,16 +1,5 @@
 import type { RaceResultDetailProps } from "./types";
-
-const ARROW_TICKET_TYPES = ["umatan", "sanrentan"];
-
-function formatHorseNumbers(
-	horses: { horse_number: number; sort_order: number }[],
-	ticketTypeName: string,
-): string {
-	const sorted = [...horses].sort((a, b) => a.sort_order - b.sort_order);
-	const numbers = sorted.map((h) => h.horse_number);
-	const separator = ARROW_TICKET_TYPES.includes(ticketTypeName) ? "→" : "-";
-	return numbers.join(separator);
-}
+import { formatHorseNumbers } from "./utils";
 
 export default function RaceResultDetail({ race }: RaceResultDetailProps) {
 	return (

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/types.ts
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/types.ts
@@ -1,0 +1,20 @@
+export type PayoutEntry = {
+	ticket_type_label: string;
+	ticket_type_name: string;
+	payout_amount: number;
+	popularity: number;
+	horses: Array<{
+		horse_number: number;
+		sort_order: number;
+	}>;
+};
+
+export type RaceResultDetailProps = {
+	race: {
+		uid: string;
+		venue_name: string;
+		race_date: string;
+		race_number: number;
+		payouts: PayoutEntry[];
+	};
+};

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/utils.ts
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/utils.ts
@@ -1,0 +1,16 @@
+const ARROW_TICKET_TYPES = ["umatan", "sanrentan"];
+
+/**
+ * 馬番リストを指定した券種の表示形式で連結した文字列を返す。
+ * sort_order 昇順に並び替えたうえで連結する。
+ * 馬単・三連単は "→"、それ以外は "-" を区切り文字として使用する。
+ */
+export function formatHorseNumbers(
+	horses: { horse_number: number; sort_order: number }[],
+	ticketTypeName: string,
+): string {
+	const sorted = [...horses].sort((a, b) => a.sort_order - b.sort_order);
+	const numbers = sorted.map((h) => h.horse_number);
+	const separator = ARROW_TICKET_TYPES.includes(ticketTypeName) ? "→" : "-";
+	return numbers.join(separator);
+}

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/utils.unit.test.ts
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/utils.unit.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { formatHorseNumbers } from "./utils";
+
+describe("formatHorseNumbers", () => {
+	it("馬番が1頭の場合（単勝など）、馬番をそのまま返す", () => {
+		// Act
+		const result = formatHorseNumbers(
+			[{ horse_number: 3, sort_order: 1 }],
+			"tansho",
+		);
+
+		// Assert
+		expect(result).toBe("3");
+	});
+
+	it("2頭・ハイフン表記（馬連など）", () => {
+		// Act
+		const result = formatHorseNumbers(
+			[
+				{ horse_number: 3, sort_order: 1 },
+				{ horse_number: 5, sort_order: 2 },
+			],
+			"umaren",
+		);
+
+		// Assert
+		expect(result).toBe("3-5");
+	});
+
+	it("3頭・ハイフン表記（三連複など）", () => {
+		// Act
+		const result = formatHorseNumbers(
+			[
+				{ horse_number: 3, sort_order: 1 },
+				{ horse_number: 5, sort_order: 2 },
+				{ horse_number: 8, sort_order: 3 },
+			],
+			"sanrenpuku",
+		);
+
+		// Assert
+		expect(result).toBe("3-5-8");
+	});
+
+	it("2頭・矢印表記（馬単）", () => {
+		// Act
+		const result = formatHorseNumbers(
+			[
+				{ horse_number: 3, sort_order: 1 },
+				{ horse_number: 5, sort_order: 2 },
+			],
+			"umatan",
+		);
+
+		// Assert
+		expect(result).toBe("3→5");
+	});
+
+	it("3頭・矢印表記（三連単）", () => {
+		// Act
+		const result = formatHorseNumbers(
+			[
+				{ horse_number: 3, sort_order: 1 },
+				{ horse_number: 5, sort_order: 2 },
+				{ horse_number: 8, sort_order: 3 },
+			],
+			"sanrentan",
+		);
+
+		// Assert
+		expect(result).toBe("3→5→8");
+	});
+
+	it("sort_order が逆順で渡されても正しく並び替えられる", () => {
+		// Act
+		const result = formatHorseNumbers(
+			[
+				{ horse_number: 8, sort_order: 3 },
+				{ horse_number: 3, sort_order: 1 },
+				{ horse_number: 5, sort_order: 2 },
+			],
+			"sanrentan",
+		);
+
+		// Assert
+		expect(result).toBe("3→5→8");
+	});
+});

--- a/source/resources/js/pages/races/result/edit.tsx
+++ b/source/resources/js/pages/races/result/edit.tsx
@@ -1,0 +1,18 @@
+import { Head, usePage } from "@inertiajs/react";
+import RaceResultDetail from "@/features/raceResult/presentational/RaceResultDetail";
+import type { RaceResultDetailProps } from "@/features/raceResult/presentational/RaceResultDetail";
+
+type RaceResultEditProps = {
+	race: RaceResultDetailProps["race"];
+};
+
+export default function RaceResultEdit() {
+	const { race } = usePage<RaceResultEditProps>().props;
+
+	return (
+		<>
+			<Head title="レース結果" />
+			<RaceResultDetail race={race} />
+		</>
+	);
+}

--- a/source/tests/Feature/Races/RaceResultTest.php
+++ b/source/tests/Feature/Races/RaceResultTest.php
@@ -858,3 +858,111 @@ test('amount が 100円より多い場合、払い戻し金額は購入金額に
         'payout_amount' => 1220,
     ]);
 });
+
+// ===== GET /races/{uid}/result/edit =====
+
+test('authenticated user can access race result edit page', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('races.result.edit', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertInertia(fn (Assert $page) => $page->component('races/result/edit'));
+});
+
+test('unauthenticated user is redirected to login page when accessing race result edit page', function () {
+    // Arrange
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    // Act
+    $response = $this->get(route('races.result.edit', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertRedirect(route('login'));
+});
+
+test('accessing race result edit page with non-existent uid returns 404', function () {
+    // Arrange
+    $user = User::factory()->create();
+
+    // Act
+    $response = $this->actingAs($user)->get(route('races.result.edit', ['uid' => 'non-existent-uid']));
+
+    // Assert
+    $response->assertNotFound();
+});
+
+test('race result edit page response includes payout fields', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    $umatanTypeId = DB::table('ticket_types')->where('name', 'umatan')->value('id');
+    $payoutId = DB::table('race_payouts')->insertGetId([
+        'race_id' => $raceId,
+        'ticket_type_id' => $umatanTypeId,
+        'payout_amount' => 2410,
+        'popularity' => 3,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    DB::table('race_payout_horses')->insert([
+        ['race_payout_id' => $payoutId, 'horse_number' => 3, 'sort_order' => 1, 'created_at' => now(), 'updated_at' => now()],
+        ['race_payout_id' => $payoutId, 'horse_number' => 5, 'sort_order' => 2, 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('races.result.edit', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertInertia(fn (Assert $page) =>
+        $page->component('races/result/edit')
+             ->has('race.payouts.0', fn (Assert $payout) =>
+                 $payout->has('ticket_type_label')
+                        ->has('ticket_type_name')
+                        ->has('payout_amount')
+                        ->has('popularity')
+                        ->has('horses')
+             )
+    );
+});
+
+test('umatan horses in race result edit page are ordered by sort_order', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    $umatanTypeId = DB::table('ticket_types')->where('name', 'umatan')->value('id');
+    $payoutId = DB::table('race_payouts')->insertGetId([
+        'race_id' => $raceId,
+        'ticket_type_id' => $umatanTypeId,
+        'payout_amount' => 2410,
+        'popularity' => 3,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+    DB::table('race_payout_horses')->insert([
+        ['race_payout_id' => $payoutId, 'horse_number' => 3, 'sort_order' => 1, 'created_at' => $now, 'updated_at' => $now],
+        ['race_payout_id' => $payoutId, 'horse_number' => 5, 'sort_order' => 2, 'created_at' => $now, 'updated_at' => $now],
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('races.result.edit', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertInertia(fn (Assert $page) =>
+        $page->component('races/result/edit')
+             ->has('race.payouts.0.horses', 2)
+             ->where('race.payouts.0.horses.0.sort_order', 1)
+             ->where('race.payouts.0.horses.0.horse_number', 3)
+             ->where('race.payouts.0.horses.1.sort_order', 2)
+             ->where('race.payouts.0.horses.1.horse_number', 5)
+    );
+});

--- a/source/tests/Feature/Races/RaceResultTest.php
+++ b/source/tests/Feature/Races/RaceResultTest.php
@@ -921,15 +921,15 @@ test('race result edit page response includes payout fields', function () {
     $response = $this->actingAs($user)->get(route('races.result.edit', ['uid' => $raceUid]));
 
     // Assert
-    $response->assertInertia(fn (Assert $page) =>
-        $page->component('races/result/edit')
-             ->has('race.payouts.0', fn (Assert $payout) =>
-                 $payout->has('ticket_type_label')
-                        ->has('ticket_type_name')
-                        ->has('payout_amount')
-                        ->has('popularity')
-                        ->has('horses')
-             )
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('races/result/edit')
+        ->has('race.payouts.0', fn (Assert $payout) => $payout
+            ->has('ticket_type_label')
+            ->has('ticket_type_name')
+            ->has('payout_amount')
+            ->has('popularity')
+            ->has('horses')
+        )
     );
 });
 
@@ -957,12 +957,12 @@ test('umatan horses in race result edit page are ordered by sort_order', functio
     $response = $this->actingAs($user)->get(route('races.result.edit', ['uid' => $raceUid]));
 
     // Assert
-    $response->assertInertia(fn (Assert $page) =>
-        $page->component('races/result/edit')
-             ->has('race.payouts.0.horses', 2)
-             ->where('race.payouts.0.horses.0.sort_order', 1)
-             ->where('race.payouts.0.horses.0.horse_number', 3)
-             ->where('race.payouts.0.horses.1.sort_order', 2)
-             ->where('race.payouts.0.horses.1.horse_number', 5)
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('races/result/edit')
+        ->has('race.payouts.0.horses', 2)
+        ->where('race.payouts.0.horses.0.sort_order', 1)
+        ->where('race.payouts.0.horses.0.horse_number', 3)
+        ->where('race.payouts.0.horses.1.sort_order', 2)
+        ->where('race.payouts.0.horses.1.horse_number', 5)
     );
 });


### PR DESCRIPTION
## やったこと

- `GET /races/{uid}/result/edit` にレース結果確認画面を実装
- 購入馬券一覧の「確認・編集」リンクから遷移すると、払戻テーブル（券種 / 馬番 / 払戻金額 / 人気）を表示
- 馬単・三連単の馬番は `→` 表記、その他は `-` 表記
- 複勝・ワイドは組み合わせごとに複数行で表示
- `ShowResultAction`（UseCase）を新規作成し、`race_payouts` と `race_payout_horses` を含むデータを返すよう実装
- Feature テスト 5 件・Vitest Unit テスト 6 件を追加

## 結果

<!--
  スクリーンショット・動画を添付する
-->

## 動作確認済み

- [ ] 購入馬券一覧の「確認・編集」リンクからレース結果確認画面へ遷移できる
- [ ] 払戻テーブルに券種・馬番・払戻金額・人気が表示される
- [ ] 馬単・三連単の馬番が `→` 表記で表示される
- [ ] 複勝・ワイドが組み合わせごとに複数行で表示される