### PR TITLE
[patch] DBアクセス方法の統一とルール明文化

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -7,3 +7,9 @@ alwaysApply: false
 ## ディレクトリ構成
 
 バックエンドファイルを作成・配置する際は必ず [docs/architecture/backend/directory-structure.md](../../docs/architecture/backend/directory-structure.md) に従うこと。
+
+## DB アクセス方法の使い分け
+
+- **基本は Eloquent Model を使う。** 単純な ID 逆引き・単一テーブルへのアクセスは必ず `TicketType::where(...)` のように Eloquent Model で行う。
+- **`DB::table()` / Query Builder は集計・JOIN クエリに限定する。** 複数テーブルをまたぐ集計や N+1 を避けたい JOIN クエリの場合のみ使用してよい。
+- **Eloquent + 手動 JOIN（`Model::query()->join()`）は使わない。** JOIN を使うなら `DB::table()` で書く。Eloquent を使うなら JOIN を避けてリレーションで取得する。

--- a/source/app/UseCases/RaceResult/StoreAction.php
+++ b/source/app/UseCases/RaceResult/StoreAction.php
@@ -6,6 +6,7 @@ use App\Models\Race;
 use App\Models\RacePayout;
 use App\Models\RacePayoutHorse;
 use App\Models\TicketPurchase;
+use App\Models\TicketType;
 use App\UseCases\TicketPurchase\CalculatePayoutAmountAction;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
@@ -58,8 +59,7 @@ class StoreAction
         $entries = $this->parse($data['text']);
         $this->validateAllTypesPresent($entries);
 
-        $ticketTypeIds = DB::table('ticket_types')
-            ->whereIn('name', self::REQUIRED_TYPES)
+        $ticketTypeIds = TicketType::whereIn('name', self::REQUIRED_TYPES)
             ->pluck('id', 'name')
             ->all();
 

--- a/source/app/UseCases/TicketPurchase/StoreAction.php
+++ b/source/app/UseCases/TicketPurchase/StoreAction.php
@@ -2,11 +2,12 @@
 
 namespace App\UseCases\TicketPurchase;
 
+use App\Models\BuyType;
 use App\Models\Race;
 use App\Models\RacePayout;
 use App\Models\TicketPurchase;
+use App\Models\TicketType;
 use App\Models\Venue;
-use Illuminate\Support\Facades\DB;
 
 class StoreAction
 {
@@ -16,13 +17,9 @@ class StoreAction
 
     public function execute(array $data, int $userId): TicketPurchase
     {
-        $ticketTypeId = DB::table('ticket_types')
-            ->where('name', $data['ticket_type'])
-            ->value('id');
+        $ticketTypeId = TicketType::where('name', $data['ticket_type'])->value('id');
 
-        $buyTypeId = DB::table('buy_types')
-            ->where('name', $data['buy_type'])
-            ->value('id');
+        $buyTypeId = BuyType::where('name', $data['buy_type'])->value('id');
 
         $raceId = null;
         if (! empty($data['race_date']) && ! empty($data['race_number'])) {


### PR DESCRIPTION
## やったこと

- `TicketPurchase/StoreAction`: `DB::table('ticket_types')` / `DB::table('buy_types')` を `TicketType::` / `BuyType::` に置換
- `RaceResult/StoreAction`: `DB::table('ticket_types')->whereIn(...)` を `TicketType::whereIn(...)` に置換
- `.claude/rules/backend.md` に DB アクセス方法の使い分けルールを追記（基本は Eloquent、集計・JOIN クエリのみ Query Builder）

## 結果

リファクタリングのため外部動作の変化なし。

## 動作確認済み

- [x] `TicketPurchaseTest.php` がパスすることを確認
- [x] `RaceResultTest.php` がパスすることを確認