### PR TITLE
[patch] サンドボックス設定を settings.json に追加する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "excludedCommands": [
+      "git:*",
+      "docker:*"
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(git status)",


### PR DESCRIPTION
## やったこと

- `.claude/settings.json` にサンドボックス設定を追加した
  - `sandbox.enabled: true` でサンドボックスを有効化
  - `sandbox.autoAllowBashIfSandboxed: true` でサンドボックス内の Bash を自動許可
  - `sandbox.excludedCommands` に `git` と `docker` を指定し、サンドボックスの制限から除外

## 結果

<\!-- スクリーンショット・動画を添付する -->

設定ファイルの変更のみのため省略。

## 動作確認済み

- [ ] 