### PR TITLE
[patch] TicketPurchaseController::index のビジネスロジックを IndexAction に切り出す

### DIFF
--- a/source/app/Http/Controllers/TicketPurchaseController.php
+++ b/source/app/Http/Controllers/TicketPurchaseController.php
@@ -3,8 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\TicketPurchase\StoreTicketPurchaseRequest;
-use App\Models\TicketPurchase;
-use App\UseCases\TicketPurchase\ExpandSelectionsAction;
+use App\UseCases\TicketPurchase\IndexAction;
 use App\UseCases\TicketPurchase\StoreAction;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -13,56 +12,13 @@ use Inertia\Response;
 
 class TicketPurchaseController extends Controller
 {
-    public function index(Request $request, ExpandSelectionsAction $expandSelections): Response
+    public function index(Request $request, IndexAction $action): Response
     {
-        $paginator = TicketPurchase::query()
-            ->where('ticket_purchases.user_id', $request->user()->id)
-            ->leftJoin('races', 'ticket_purchases.race_id', '=', 'races.id')
-            ->leftJoin('venues', 'races.venue_id', '=', 'venues.id')
-            ->join('ticket_types', 'ticket_purchases.ticket_type_id', '=', 'ticket_types.id')
-            ->join('buy_types', 'ticket_purchases.buy_type_id', '=', 'buy_types.id')
-            ->select([
-                'ticket_purchases.id',
-                'ticket_purchases.selections',
-                'ticket_purchases.amount',
-                'ticket_purchases.payout_amount',
-                'races.uid as race_uid',
-                'races.race_date',
-                'venues.name as venue_name',
-                'races.race_number',
-                'ticket_types.name as ticket_type_name',
-                'ticket_types.label as ticket_type_label',
-                'buy_types.name as buy_type_name',
-            ])
-            ->selectRaw('EXISTS(SELECT 1 FROM race_payouts WHERE race_payouts.race_id = races.id) as has_race_result')
-            ->orderByDesc('race_date')
-            ->orderByDesc('venue_name')
-            ->orderByDesc('race_number')
-            ->cursorPaginate(30);
-
-        $purchases = $paginator->map(fn (TicketPurchase $purchase) => [
-            'id' => $purchase->id,
-            'race_uid' => $purchase->race_uid,
-            'has_race_result' => (bool) $purchase->has_race_result,
-            'race_date' => $purchase->race_date,
-            'venue_name' => $purchase->venue_name,
-            'race_number' => $purchase->race_number,
-            'ticket_type_label' => $purchase->ticket_type_label,
-            'buy_type_name' => $purchase->buy_type_name,
-            'selections' => $purchase->selections,
-            'amount' => $purchase->amount !== null
-                ? $purchase->amount * count($expandSelections->execute(
-                    $purchase->ticket_type_name,
-                    $purchase->buy_type_name,
-                    $purchase->selections,
-                ))
-                : null,
-            'payout_amount' => $purchase->payout_amount !== null ? (int) $purchase->payout_amount : null,
-        ]);
+        $result = $action->execute($request->user()->id);
 
         return Inertia::render('tickets/index', [
-            'purchases' => Inertia::merge(fn () => $purchases),
-            'nextCursor' => $paginator->nextCursor()?->encode(),
+            'purchases' => Inertia::merge(fn () => $result['purchases']),
+            'nextCursor' => $result['nextCursor'],
         ]);
     }
 

--- a/source/app/UseCases/TicketPurchase/IndexAction.php
+++ b/source/app/UseCases/TicketPurchase/IndexAction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\UseCases\TicketPurchase;
+
+use App\Models\TicketPurchase;
+
+/**
+ * 認証ユーザーの馬券購入一覧（カーソルページネーション付き）を返す。
+ *
+ * JOIN クエリ・金額計算・ExpandSelectionsAction 呼び出しを集約し、
+ * Controller から切り出すことで薄いコントローラー設計を保つ。
+ */
+class IndexAction
+{
+    public function __construct(
+        private ExpandSelectionsAction $expandSelections,
+    ) {}
+
+    /**
+     * @return array{
+     *   purchases: list<array{
+     *     id: int,
+     *     race_uid: string|null,
+     *     has_race_result: bool,
+     *     race_date: string|null,
+     *     venue_name: string|null,
+     *     race_number: int|null,
+     *     ticket_type_label: string,
+     *     buy_type_name: string,
+     *     selections: array<mixed>|null,
+     *     amount: int|null,
+     *     payout_amount: int|null,
+     *   }>,
+     *   nextCursor: string|null,
+     * }
+     */
+    public function execute(int $userId): array
+    {
+        // TODO: TicketPurchaseController::index から移行する
+        throw new \LogicException('Not implemented');
+    }
+}

--- a/source/app/UseCases/TicketPurchase/IndexAction.php
+++ b/source/app/UseCases/TicketPurchase/IndexAction.php
@@ -36,7 +36,54 @@ class IndexAction
      */
     public function execute(int $userId): array
     {
-        // TODO: TicketPurchaseController::index から移行する
-        throw new \LogicException('Not implemented');
+        $paginator = TicketPurchase::query()
+            ->where('ticket_purchases.user_id', $userId)
+            ->leftJoin('races', 'ticket_purchases.race_id', '=', 'races.id')
+            ->leftJoin('venues', 'races.venue_id', '=', 'venues.id')
+            ->join('ticket_types', 'ticket_purchases.ticket_type_id', '=', 'ticket_types.id')
+            ->join('buy_types', 'ticket_purchases.buy_type_id', '=', 'buy_types.id')
+            ->select([
+                'ticket_purchases.id',
+                'ticket_purchases.selections',
+                'ticket_purchases.amount',
+                'ticket_purchases.payout_amount',
+                'races.uid as race_uid',
+                'races.race_date',
+                'venues.name as venue_name',
+                'races.race_number',
+                'ticket_types.name as ticket_type_name',
+                'ticket_types.label as ticket_type_label',
+                'buy_types.name as buy_type_name',
+            ])
+            ->selectRaw('EXISTS(SELECT 1 FROM race_payouts WHERE race_payouts.race_id = races.id) as has_race_result')
+            ->orderByDesc('race_date')
+            ->orderByDesc('venue_name')
+            ->orderByDesc('race_number')
+            ->cursorPaginate(30);
+
+        $purchases = $paginator->map(fn (TicketPurchase $purchase) => [
+            'id' => $purchase->id,
+            'race_uid' => $purchase->race_uid,
+            'has_race_result' => (bool) $purchase->has_race_result,
+            'race_date' => $purchase->race_date,
+            'venue_name' => $purchase->venue_name,
+            'race_number' => $purchase->race_number,
+            'ticket_type_label' => $purchase->ticket_type_label,
+            'buy_type_name' => $purchase->buy_type_name,
+            'selections' => $purchase->selections,
+            'amount' => $purchase->amount !== null
+                ? $purchase->amount * count($this->expandSelections->execute(
+                    $purchase->ticket_type_name,
+                    $purchase->buy_type_name,
+                    $purchase->selections,
+                ))
+                : null,
+            'payout_amount' => $purchase->payout_amount !== null ? (int) $purchase->payout_amount : null,
+        ]);
+
+        return [
+            'purchases' => $purchases->all(),
+            'nextCursor' => $paginator->nextCursor()?->encode(),
+        ];
     }
 }


### PR DESCRIPTION
## やったこと

- `TicketPurchaseController::index` に直書きされていた JOIN クエリ・金額計算・`ExpandSelectionsAction` 呼び出しなどのビジネスロジックを `App\UseCases\TicketPurchase\IndexAction` に移行した
- Controller は `IndexAction::execute(int $userId)` を呼び出して結果を `Inertia::render` に渡すだけの薄い実装になった
- 外部から見たレスポンスデータ構造・ページネーション動作は変更なし

## 結果

既存テスト（`TicketPurchaseListTest`）17件すべて通過

## 動作確認済み

- [ ] 馬券一覧画面（/tickets）で購入履歴・ページネーション・金額表示が従来通り表示されること