### PR TITLE
[patch] 日付フォーマット処理をユーティリティ関数に切り出す

### DIFF
--- a/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.tsx
+++ b/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.tsx
@@ -11,6 +11,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/shadcn/ui/select";
+import { formatDateDisplay } from "@/utils/date";
 import type { BalanceDashboardProps } from "./types";
 
 export default function BalanceDashboard({
@@ -163,7 +164,7 @@ export default function BalanceDashboard({
 										key={row.date}
 										className="border-b last:border-0 hover:bg-muted/30"
 									>
-										<td className="px-4 py-3">{row.date.replace(/-/g, "/")}</td>
+										<td className="px-4 py-3">{formatDateDisplay(row.date)}</td>
 										<td className="px-4 py-3 text-right">
 											¥{row.purchase_amount.toLocaleString()}
 										</td>

--- a/source/resources/js/features/raceDetail/presentational/RaceDetail/index.tsx
+++ b/source/resources/js/features/raceDetail/presentational/RaceDetail/index.tsx
@@ -1,3 +1,4 @@
+import { formatDateDisplay } from "@/utils/date";
 import type { RaceDetailProps } from "./types";
 
 export default function RaceDetail({ race }: RaceDetailProps) {
@@ -12,7 +13,7 @@ export default function RaceDetail({ race }: RaceDetailProps) {
 							<th className="w-32 bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
 								開催日
 							</th>
-							<td className="px-4 py-3">{race.race_date.replace(/-/g, "/")}</td>
+							<td className="px-4 py-3">{formatDateDisplay(race.race_date)}</td>
 						</tr>
 						<tr className="border-b">
 							<th className="bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">

--- a/source/resources/js/features/raceList/presentational/RaceList/index.tsx
+++ b/source/resources/js/features/raceList/presentational/RaceList/index.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/shadcn/ui/button";
 import { Input } from "@/components/shadcn/ui/input";
 import { Label } from "@/components/shadcn/ui/label";
 import { create, show } from "@/routes/races";
+import { formatDateDisplay } from "@/utils/date";
 import type { RaceListProps } from "./types";
 
 export default function RaceList({
@@ -94,7 +95,7 @@ export default function RaceList({
 									}}
 								>
 									<td className="px-4 py-3">
-										{race.race_date.replace(/-/g, "/")}
+										{formatDateDisplay(race.race_date)}
 									</td>
 									<td className="px-4 py-3">{race.venue_name}</td>
 									<td className="px-4 py-3">{race.race_number}R</td>

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -1,3 +1,4 @@
+import { formatDateDisplay } from "@/utils/date";
 import type { RaceResultDetailProps } from "./types";
 import { formatHorseNumbers } from "./utils";
 
@@ -7,7 +8,7 @@ export default function RaceResultDetail({ race }: RaceResultDetailProps) {
 			<div>
 				<h1 className="text-xl font-semibold">レース結果</h1>
 				<p className="text-sm text-muted-foreground">
-					{race.race_date.replace(/-/g, "/")} {race.venue_name}{" "}
+					{formatDateDisplay(race.race_date)} {race.venue_name}{" "}
 					{race.race_number}R
 				</p>
 			</div>

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/shadcn/ui/button";
 import AlertError from "@/components/presentational/AlertError";
+import { formatDateDisplay } from "@/utils/date";
 import type { RaceResultFormProps } from "./types";
 
 export default function RaceResultForm({
@@ -20,7 +21,7 @@ export default function RaceResultForm({
 			<div>
 				<h1 className="text-xl font-semibold">レース結果入力</h1>
 				<p className="text-sm text-muted-foreground">
-					{raceDate.replace(/-/g, "/")} {venueName} {raceNumber}R
+					{formatDateDisplay(raceDate)} {venueName} {raceNumber}R
 				</p>
 			</div>
 

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseList/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseList/index.tsx
@@ -2,6 +2,7 @@ import { Link } from "@inertiajs/react";
 import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { newMethod } from "@/routes/tickets";
+import { formatDateDisplay } from "@/utils/date";
 import type { TicketPurchaseListProps } from "./types";
 import { formatSelections } from "./utils";
 
@@ -65,7 +66,7 @@ export default function TicketPurchaseList({
 									>
 										<td className="px-4 py-3">
 											{purchase.race_date
-												? purchase.race_date.replace(/-/g, "/")
+												? formatDateDisplay(purchase.race_date)
 												: "-"}
 										</td>
 										<td className="px-4 py-3">{purchase.venue_name ?? "-"}</td>

--- a/source/resources/js/utils/date.ts
+++ b/source/resources/js/utils/date.ts
@@ -1,0 +1,13 @@
+/**
+ * ハイフン区切りの日付文字列を、表示用のスラッシュ区切りに変換する。
+ *
+ * バックエンドから受け取る日付は ISO 8601 準拠の `YYYY-MM-DD` 形式（例: `"2026-04-25"`）だが、
+ * 画面表示では国内の慣習に合わせた `YYYY/MM/DD` 形式（例: `"2026/04/25"`）を用いる。
+ *
+ * @param date - `YYYY-MM-DD` 形式の日付文字列。フォーマット検証は行わないため、
+ *               想定外の形式が渡された場合はハイフンのみがスラッシュに置換される。
+ * @returns `YYYY/MM/DD` 形式に変換された日付文字列。
+ */
+export function formatDateDisplay(date: string): string {
+	return date.replace(/-/g, "/");
+}

--- a/source/resources/js/utils/date.unit.test.ts
+++ b/source/resources/js/utils/date.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { formatDateDisplay } from "@/utils/date";
+
+describe("formatDateDisplay", () => {
+	it("ハイフン区切りの日付をスラッシュ区切りに変換する", () => {
+		// Arrange
+		const input = "2026-04-25";
+
+		// Act
+		const result = formatDateDisplay(input);
+
+		// Assert
+		expect(result).toBe("2026/04/25");
+	});
+
+	it("月初・年始の日付をスラッシュ区切りに変換する", () => {
+		// Arrange
+		const input = "2026-01-01";
+
+		// Act
+		const result = formatDateDisplay(input);
+
+		// Assert
+		expect(result).toBe("2026/01/01");
+	});
+
+	it("月末・年末の日付をスラッシュ区切りに変換する", () => {
+		// Arrange
+		const input = "2026-12-31";
+
+		// Act
+		const result = formatDateDisplay(input);
+
+		// Assert
+		expect(result).toBe("2026/12/31");
+	});
+});


### PR DESCRIPTION
## やったこと

- `resources/js/utils/date.ts` に `formatDateDisplay(date: string): string` を新規作成
- コードベース内で重複していた `replace(/-/g, "/")` を全6か所でユーティリティ関数呼び出しに置き換え
  - `features/ticket/presentational/TicketPurchaseList/index.tsx`
  - `features/dashboard/presentational/BalanceDashboard/index.tsx`
  - `features/raceList/presentational/RaceList/index.tsx`
  - `features/raceDetail/presentational/RaceDetail/index.tsx`
  - `features/raceResult/presentational/RaceResultDetail/index.tsx`
  - `features/raceResult/presentational/RaceResultForm/index.tsx`
- `resources/js/utils/date.unit.test.ts` にユニットテストを追加（3ケース）

## 結果

表示形式の変更なし（`YYYY-MM-DD` → `YYYY/MM/DD` の変換は従来通り）

## 動作確認済み

- [x] 各画面で日付が `YYYY/MM/DD` 形式で表示されること