### PR TITLE
[patch] StorybookのStoryファイルtitleフィールドをディレクトリパスに統一する

### DIFF
--- a/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.stories.tsx
+++ b/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.stories.tsx
@@ -3,7 +3,7 @@ import BalanceDashboard from ".";
 import type { BalanceDashboardProps } from ".";
 
 const meta: Meta<typeof BalanceDashboard> = {
-	title: "features/dashboard/BalanceDashboard",
+	title: "features/dashboard/presentational/BalanceDashboard",
 	component: BalanceDashboard,
 };
 

--- a/source/resources/js/features/raceDetail/presentational/RaceDetail/RaceDetail.stories.tsx
+++ b/source/resources/js/features/raceDetail/presentational/RaceDetail/RaceDetail.stories.tsx
@@ -3,7 +3,7 @@ import RaceDetail from ".";
 import type { RaceDetailProps } from ".";
 
 const meta: Meta<typeof RaceDetail> = {
-	title: "features/raceDetail/RaceDetail",
+	title: "features/raceDetail/presentational/RaceDetail",
 	component: RaceDetail,
 };
 

--- a/source/resources/js/features/raceInput/presentational/RaceInputForm/RaceInputForm.stories.tsx
+++ b/source/resources/js/features/raceInput/presentational/RaceInputForm/RaceInputForm.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import RaceInputForm from ".";
 
 const meta: Meta<typeof RaceInputForm> = {
-	title: "features/raceInput/RaceInputForm",
+	title: "features/raceInput/presentational/RaceInputForm",
 	component: RaceInputForm,
 };
 

--- a/source/resources/js/features/raceList/presentational/RaceList/index.stories.tsx
+++ b/source/resources/js/features/raceList/presentational/RaceList/index.stories.tsx
@@ -3,7 +3,7 @@ import RaceList from ".";
 import type { RaceListProps } from ".";
 
 const meta: Meta<typeof RaceList> = {
-	title: "RaceList",
+	title: "features/raceList/presentational/RaceList",
 	component: RaceList,
 };
 

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
@@ -3,7 +3,7 @@ import RaceResultDetail from ".";
 import type { RaceResultDetailProps } from ".";
 
 const meta: Meta<typeof RaceResultDetail> = {
-	title: "features/raceResult/RaceResultDetail",
+	title: "features/raceResult/presentational/RaceResultDetail",
 	component: RaceResultDetail,
 };
 

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/index.stories.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/index.stories.tsx
@@ -3,7 +3,7 @@ import RaceResultForm from ".";
 import type { RaceResultFormProps } from ".";
 
 const meta: Meta<typeof RaceResultForm> = {
-	title: "RaceResultForm",
+	title: "features/raceResult/presentational/RaceResultForm",
 	component: RaceResultForm,
 };
 

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketPurchaseForm.stories.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketPurchaseForm.stories.tsx
@@ -3,7 +3,7 @@ import TicketPurchaseForm from ".";
 import type { TicketPurchaseFormProps } from ".";
 
 const meta: Meta<typeof TicketPurchaseForm> = {
-	title: "TicketPurchaseForm",
+	title: "features/ticket/presentational/TicketPurchaseForm",
 	component: TicketPurchaseForm,
 };
 

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseList/index.stories.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseList/index.stories.tsx
@@ -3,7 +3,7 @@ import TicketPurchaseList from ".";
 import type { TicketPurchaseListProps } from ".";
 
 const meta: Meta<typeof TicketPurchaseList> = {
-	title: "TicketPurchaseList",
+	title: "features/ticket/presentational/TicketPurchaseList",
 	component: TicketPurchaseList,
 };
 


### PR DESCRIPTION
## やったこと

- 8ファイルの Storybook `title` フィールドを実際のディレクトリパスに統一した
  - `RaceResultForm` → `features/raceResult/presentational/RaceResultForm`
  - `TicketPurchaseForm` → `features/ticket/presentational/TicketPurchaseForm`
  - `TicketPurchaseList` → `features/ticket/presentational/TicketPurchaseList`
  - `RaceList` → `features/raceList/presentational/RaceList`
  - `features/dashboard/BalanceDashboard` → `features/dashboard/presentational/BalanceDashboard`
  - `features/raceInput/RaceInputForm` → `features/raceInput/presentational/RaceInputForm`
  - `features/raceDetail/RaceDetail` → `features/raceDetail/presentational/RaceDetail`
  - `features/raceResult/RaceResultDetail` → `features/raceResult/presentational/RaceResultDetail`（issue対象外だが同様の問題があったため合わせて修正）

## 結果

Storybookのサイドバーで各コンポーネントが `presentational` 階層を含む正しいパスに表示されるようになる

## 動作確認済み

- [ ] Storybookを起動し、サイドバーで全8コンポーネントが正しいパス階層に表示されることを確認