### PR TITLE
[patch] TicketPurchaseForm をサブコンポーネントに分割するリファクタリング

### DIFF
--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseSelectionSection/HorseSelectionSection.stories.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseSelectionSection/HorseSelectionSection.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { HorseSelectionSection } from ".";
+
+const meta: Meta<typeof HorseSelectionSection> = {
+	title: "features/ticket/HorseSelectionSection",
+	component: HorseSelectionSection,
+};
+
+export default meta;
+type Story = StoryObj<typeof HorseSelectionSection>;
+
+export const Tansho: Story = {
+	name: "単勝・通常（複数頭選択）",
+	args: {
+		selectedTicketTypeId: "tansho",
+		selectedBuyTypeId: "single",
+		selectedAxisCount: 1,
+		selectedNagashiDirection: 1,
+		selectedHorses: { horses: [5] },
+		onAxisCountChange: () => {},
+		onNagashiDirectionChange: () => {},
+		onHorsesChange: () => {},
+	},
+};
+
+export const UmarenBox: Story = {
+	name: "馬連・ボックス（複数頭選択）",
+	args: {
+		selectedTicketTypeId: "umaren",
+		selectedBuyTypeId: "box",
+		selectedAxisCount: 1,
+		selectedNagashiDirection: 1,
+		selectedHorses: { horses: [1, 3, 5] },
+		onAxisCountChange: () => {},
+		onNagashiDirectionChange: () => {},
+		onHorsesChange: () => {},
+	},
+};
+
+export const UmarenNagashi: Story = {
+	name: "馬連・流し（軸1頭＋相手）",
+	args: {
+		selectedTicketTypeId: "umaren",
+		selectedBuyTypeId: "nagashi",
+		selectedAxisCount: 1,
+		selectedNagashiDirection: 1,
+		selectedHorses: { axis: [3], others: [1, 5, 7] },
+		onAxisCountChange: () => {},
+		onNagashiDirectionChange: () => {},
+		onHorsesChange: () => {},
+	},
+};
+
+export const SanrenpukuNagashi1jiku: Story = {
+	name: "三連複・流し・1頭軸（軸頭数セレクター表示）",
+	args: {
+		selectedTicketTypeId: "sanrenpuku",
+		selectedBuyTypeId: "nagashi",
+		selectedAxisCount: 1,
+		selectedNagashiDirection: 1,
+		selectedHorses: { axis: [3], others: [1, 5, 7, 9] },
+		onAxisCountChange: () => {},
+		onNagashiDirectionChange: () => {},
+		onHorsesChange: () => {},
+	},
+};
+
+export const SanrenpukuNagashi2jiku: Story = {
+	name: "三連複・流し・2頭軸（軸頭数セレクター表示）",
+	args: {
+		selectedTicketTypeId: "sanrenpuku",
+		selectedBuyTypeId: "nagashi",
+		selectedAxisCount: 2,
+		selectedNagashiDirection: 1,
+		selectedHorses: { axis1: [3], axis2: [5], others: [1, 7, 9] },
+		onAxisCountChange: () => {},
+		onNagashiDirectionChange: () => {},
+		onHorsesChange: () => {},
+	},
+};
+
+export const SanrentanNagashi: Story = {
+	name: "三連単・流し（流し方向セレクター表示）",
+	args: {
+		selectedTicketTypeId: "sanrentan",
+		selectedBuyTypeId: "nagashi",
+		selectedAxisCount: 1,
+		selectedNagashiDirection: 1,
+		selectedHorses: { col1: [3], col2: [1, 5, 7], col3: [1, 5, 7] },
+		onAxisCountChange: () => {},
+		onNagashiDirectionChange: () => {},
+		onHorsesChange: () => {},
+	},
+};
+
+export const SanrentanFormation: Story = {
+	name: "三連単・フォーメーション（着順別）",
+	args: {
+		selectedTicketTypeId: "sanrentan",
+		selectedBuyTypeId: "formation",
+		selectedAxisCount: 1,
+		selectedNagashiDirection: 1,
+		selectedHorses: { col1: [1, 2], col2: [3, 4], col3: [5, 6, 7] },
+		onAxisCountChange: () => {},
+		onNagashiDirectionChange: () => {},
+		onHorsesChange: () => {},
+	},
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseSelectionSection/HorseSelectionSection.unit.test.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseSelectionSection/HorseSelectionSection.unit.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { HorseSelectionSection } from ".";
+import type { HorseSelectionSectionProps } from "./types";
+
+const noop = () => {};
+
+const baseProps: HorseSelectionSectionProps = {
+	selectedTicketTypeId: "umaren",
+	selectedBuyTypeId: "nagashi",
+	selectedAxisCount: 1,
+	selectedNagashiDirection: 1,
+	selectedHorses: { axis: [3], others: [1, 5, 7] },
+	onAxisCountChange: noop,
+	onNagashiDirectionChange: noop,
+	onHorsesChange: noop,
+};
+
+describe("HorseSelectionSection", () => {
+	describe("レンダリング", () => {
+		it("「馬番」セクションタイトルが表示される", () => {
+			// Act
+			render(<HorseSelectionSection {...baseProps} />);
+
+			// Assert
+			expect(screen.getByText("馬番")).toBeInTheDocument();
+		});
+	});
+
+	describe("馬番グリッド", () => {
+		it("枠連（wakuren）のグリッドは 1〜8 の 8 個表示される", () => {
+			// Act
+			render(
+				<HorseSelectionSection
+					{...baseProps}
+					selectedTicketTypeId="wakuren"
+					selectedBuyTypeId="nagashi"
+					selectedAxisCount={1}
+					selectedHorses={{ axis: [], others: [] }}
+				/>,
+			);
+
+			// Assert
+			for (let i = 1; i <= 8; i++) {
+				expect(
+					screen.getAllByRole("button", { name: `${i}番` }).length,
+				).toBeGreaterThanOrEqual(1);
+			}
+			expect(
+				screen.queryByRole("button", { name: "9番" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("枠連以外のグリッドは 1〜18 の 18 個表示される", () => {
+			// Act
+			render(
+				<HorseSelectionSection
+					{...baseProps}
+					selectedTicketTypeId="umaren"
+					selectedBuyTypeId="nagashi"
+					selectedAxisCount={1}
+					selectedHorses={{ axis: [], others: [] }}
+				/>,
+			);
+
+			// Assert
+			for (let i = 1; i <= 18; i++) {
+				expect(
+					screen.getAllByRole("button", { name: `${i}番` }).length,
+				).toBeGreaterThanOrEqual(1);
+			}
+			expect(
+				screen.queryByRole("button", { name: "19番" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("selectedHorses に含まれる馬番ボタンが aria-pressed=true になる", () => {
+			// Act
+			render(
+				<HorseSelectionSection
+					{...baseProps}
+					selectedTicketTypeId="tansho"
+					selectedBuyTypeId="single"
+					selectedHorses={{ horses: [3, 7] }}
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByRole("button", { name: "3番" })).toHaveAttribute(
+				"aria-pressed",
+				"true",
+			);
+			expect(screen.getByRole("button", { name: "7番" })).toHaveAttribute(
+				"aria-pressed",
+				"true",
+			);
+			expect(screen.getByRole("button", { name: "1番" })).toHaveAttribute(
+				"aria-pressed",
+				"false",
+			);
+		});
+	});
+
+	describe("条件付き UI 要素", () => {
+		it("三連複（sanrenpuku）+ 流し（nagashi）のとき「軸の頭数」セレクタが表示される", () => {
+			// Act
+			render(
+				<HorseSelectionSection
+					{...baseProps}
+					selectedTicketTypeId="sanrenpuku"
+					selectedBuyTypeId="nagashi"
+					selectedAxisCount={1}
+					selectedHorses={{ axis: [], others: [] }}
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByText("軸の頭数")).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: "1頭軸" }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: "2頭軸" }),
+			).toBeInTheDocument();
+		});
+
+		it("三連単（sanrentan）+ 流し（nagashi）のとき「流し方向」セレクタが表示される", () => {
+			// Act
+			render(
+				<HorseSelectionSection
+					{...baseProps}
+					selectedTicketTypeId="sanrentan"
+					selectedBuyTypeId="nagashi"
+					selectedNagashiDirection={1}
+					selectedHorses={{ col1: [], col2: [], col3: [] }}
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByText("流し方向")).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: "1着流し" }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: "2着流し" }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: "3着流し" }),
+			).toBeInTheDocument();
+		});
+
+		it("三連複（sanrenpuku）+ フォーメーション（formation）のとき「1列目」「2列目」「3列目」ラベルが表示される", () => {
+			// Act
+			render(
+				<HorseSelectionSection
+					{...baseProps}
+					selectedTicketTypeId="sanrenpuku"
+					selectedBuyTypeId="formation"
+					selectedHorses={{ col1: [], col2: [], col3: [] }}
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByText("1列目")).toBeInTheDocument();
+			expect(screen.getByText("2列目")).toBeInTheDocument();
+			expect(screen.getByText("3列目")).toBeInTheDocument();
+		});
+
+		it("三連複（sanrenpuku）+ フォーメーション（formation）のとき「軸の頭数」セレクタが表示されない", () => {
+			// Act
+			render(
+				<HorseSelectionSection
+					{...baseProps}
+					selectedTicketTypeId="sanrenpuku"
+					selectedBuyTypeId="formation"
+					selectedHorses={{ col1: [], col2: [], col3: [] }}
+				/>,
+			);
+
+			// Assert
+			expect(screen.queryByText("軸の頭数")).not.toBeInTheDocument();
+		});
+
+		it("三連単（sanrentan）+ 流し（nagashi）以外では「流し方向」セレクタが表示されない", () => {
+			// Act
+			render(
+				<HorseSelectionSection
+					{...baseProps}
+					selectedTicketTypeId="umaren"
+					selectedBuyTypeId="nagashi"
+					selectedHorses={{ axis: [], others: [] }}
+				/>,
+			);
+
+			// Assert
+			expect(screen.queryByText("流し方向")).not.toBeInTheDocument();
+		});
+	});
+});

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseSelectionSection/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseSelectionSection/index.tsx
@@ -1,0 +1,109 @@
+import { Button } from "@/components/shadcn/ui/button";
+import { Label } from "@/components/shadcn/ui/label";
+import { GRID_SIZE, HORSE_INPUT_CONFIG } from "../constants";
+import { HorseGrid } from "../HorseGrid";
+import { Section } from "../Section";
+import { getHorseInputConfigKey } from "../utils";
+import type { HorseSelectionSectionProps } from "./types";
+
+export function HorseSelectionSection({
+	selectedTicketTypeId,
+	selectedBuyTypeId,
+	selectedAxisCount,
+	selectedNagashiDirection,
+	selectedHorses,
+	onAxisCountChange,
+	onNagashiDirectionChange,
+	onHorsesChange,
+}: HorseSelectionSectionProps) {
+	const gridSize = GRID_SIZE[selectedTicketTypeId] ?? 18;
+
+	const showAxisCountSelector =
+		selectedBuyTypeId === "nagashi" && selectedTicketTypeId === "sanrenpuku";
+
+	const showNagashiDirectionSelector =
+		selectedBuyTypeId === "nagashi" && selectedTicketTypeId === "sanrentan";
+
+	const horseInputConfigKey = getHorseInputConfigKey(
+		selectedTicketTypeId,
+		selectedBuyTypeId,
+		selectedAxisCount,
+		selectedNagashiDirection,
+	);
+
+	const horseGroups = HORSE_INPUT_CONFIG[horseInputConfigKey] ?? [];
+
+	const handleHorseToggle = (groupKey: string, num: number) => {
+		const current = selectedHorses[groupKey] ?? [];
+		const next = current.includes(num)
+			? current.filter((n) => n !== num)
+			: [...current, num];
+		onHorsesChange(groupKey, next);
+	};
+
+	const handleHorseTextChange = (groupKey: string, text: string) => {
+		const nums = text
+			.split(/[\s,]+/)
+			.map(Number)
+			.filter((n) => Number.isInteger(n) && n >= 1 && n <= gridSize);
+		onHorsesChange(groupKey, nums);
+	};
+
+	return (
+		<Section title="馬番">
+			<div className="space-y-6">
+				{showAxisCountSelector && (
+					<div className="space-y-2">
+						<Label>軸の頭数</Label>
+						<div className="flex gap-2">
+							{([1, 2] as const).map((count) => (
+								<Button
+									key={count}
+									type="button"
+									variant={count === selectedAxisCount ? "default" : "outline"}
+									size="sm"
+									aria-pressed={count === selectedAxisCount}
+									onClick={() => onAxisCountChange(count)}
+								>
+									{count}頭軸
+								</Button>
+							))}
+						</div>
+					</div>
+				)}
+				{showNagashiDirectionSelector && (
+					<div className="space-y-2">
+						<Label>流し方向</Label>
+						<div className="flex gap-2">
+							{([1, 2, 3] as const).map((pos) => (
+								<Button
+									key={pos}
+									type="button"
+									variant={
+										pos === selectedNagashiDirection ? "default" : "outline"
+									}
+									size="sm"
+									aria-pressed={pos === selectedNagashiDirection}
+									onClick={() => onNagashiDirectionChange(pos)}
+								>
+									{pos}着流し
+								</Button>
+							))}
+						</div>
+					</div>
+				)}
+				{horseGroups.map(({ key, label }) => (
+					<HorseGrid
+						key={key}
+						groupKey={key}
+						label={label}
+						gridSize={gridSize}
+						selectedHorses={selectedHorses[key] ?? []}
+						onToggle={(num) => handleHorseToggle(key, num)}
+						onTextChange={(text) => handleHorseTextChange(key, text)}
+					/>
+				))}
+			</div>
+		</Section>
+	);
+}

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseSelectionSection/types.ts
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseSelectionSection/types.ts
@@ -1,0 +1,12 @@
+import type { TicketTypeId } from "../constants";
+
+export type HorseSelectionSectionProps = {
+	selectedTicketTypeId: TicketTypeId;
+	selectedBuyTypeId: string;
+	selectedAxisCount: 1 | 2;
+	selectedNagashiDirection: 1 | 2 | 3;
+	selectedHorses: Record<string, number[]>;
+	onAxisCountChange: (count: 1 | 2) => void;
+	onNagashiDirectionChange: (pos: 1 | 2 | 3) => void;
+	onHorsesChange: (groupKey: string, horses: number[]) => void;
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/RaceInfoSection/RaceInfoSection.stories.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/RaceInfoSection/RaceInfoSection.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RaceInfoSection } from ".";
+
+const meta: Meta<typeof RaceInfoSection> = {
+	title: "features/ticket/RaceInfoSection",
+	component: RaceInfoSection,
+};
+
+export default meta;
+type Story = StoryObj<typeof RaceInfoSection>;
+
+export const Default: Story = {
+	name: "デフォルト",
+	args: {
+		selectedVenue: "東京",
+		selectedRaceDate: "2026-04-05",
+		selectedRaceNumber: 1,
+		onVenueChange: () => {},
+		onRaceDateChange: () => {},
+		onRaceNumberChange: () => {},
+	},
+};
+
+export const SelectedRace5: Story = {
+	name: "5レース選択済み",
+	args: {
+		selectedVenue: "阪神",
+		selectedRaceDate: "2026-04-05",
+		selectedRaceNumber: 5,
+		onVenueChange: () => {},
+		onRaceDateChange: () => {},
+		onRaceNumberChange: () => {},
+	},
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/RaceInfoSection/RaceInfoSection.unit.test.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/RaceInfoSection/RaceInfoSection.unit.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RaceInfoSection } from ".";
+import type { RaceInfoSectionProps } from "./types";
+
+const noop = () => {};
+
+const baseProps: RaceInfoSectionProps = {
+	selectedVenue: "東京",
+	selectedRaceDate: "2026-04-05",
+	selectedRaceNumber: 1,
+	onVenueChange: noop,
+	onRaceDateChange: noop,
+	onRaceNumberChange: noop,
+};
+
+describe("RaceInfoSection", () => {
+	describe("レンダリング", () => {
+		it("「レース情報」セクションタイトルが表示される", () => {
+			// Act
+			render(<RaceInfoSection {...baseProps} />);
+
+			// Assert
+			expect(screen.getByText("レース情報")).toBeInTheDocument();
+		});
+
+		it("「開催場所」ラベルとSelectが表示される", () => {
+			// Act
+			render(<RaceInfoSection {...baseProps} />);
+
+			// Assert
+			expect(screen.getByLabelText("開催場所")).toBeInTheDocument();
+		});
+
+		it("「開催日」ラベルとdate inputが表示される", () => {
+			// Act
+			render(<RaceInfoSection {...baseProps} />);
+
+			// Assert
+			expect(screen.getByLabelText("開催日")).toBeInTheDocument();
+		});
+
+		it("「レース番号」ラベルと 1〜12 のボタンが表示される", () => {
+			// Act
+			render(<RaceInfoSection {...baseProps} />);
+
+			// Assert
+			expect(
+				screen.getByLabelText("レース番号を直接入力"),
+			).toBeInTheDocument();
+			for (let r = 1; r <= 12; r++) {
+				expect(
+					screen.getByRole("button", { name: `${r}R` }),
+				).toBeInTheDocument();
+			}
+		});
+	});
+
+	describe("選択状態の表示", () => {
+		it("selectedRaceNumber に対応するレース番号ボタンのみ aria-pressed=true になる", () => {
+			// Act
+			render(<RaceInfoSection {...baseProps} selectedRaceNumber={5} />);
+
+			// Assert
+			expect(screen.getByRole("button", { name: "5R" })).toHaveAttribute(
+				"aria-pressed",
+				"true",
+			);
+			expect(screen.getByRole("button", { name: "1R" })).toHaveAttribute(
+				"aria-pressed",
+				"false",
+			);
+		});
+	});
+});

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/RaceInfoSection/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/RaceInfoSection/index.tsx
@@ -1,0 +1,89 @@
+import { Button } from "@/components/shadcn/ui/button";
+import { Input } from "@/components/shadcn/ui/input";
+import { Label } from "@/components/shadcn/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/shadcn/ui/select";
+import { VENUES } from "../constants";
+import { Section } from "../Section";
+import type { RaceInfoSectionProps } from "./types";
+
+export function RaceInfoSection({
+	selectedVenue,
+	selectedRaceDate,
+	selectedRaceNumber,
+	onVenueChange,
+	onRaceDateChange,
+	onRaceNumberChange,
+}: RaceInfoSectionProps) {
+	return (
+		<Section title="レース情報">
+			<div className="space-y-4">
+				<div className="space-y-2">
+					<Label htmlFor="venue">開催場所</Label>
+					<Select value={selectedVenue} onValueChange={onVenueChange}>
+						<SelectTrigger id="venue" className="w-40">
+							<SelectValue placeholder="選択してください" />
+						</SelectTrigger>
+						<SelectContent>
+							{VENUES.map((venue) => (
+								<SelectItem key={venue} value={venue}>
+									{venue}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				<div className="space-y-2">
+					<Label htmlFor="race-date">開催日</Label>
+					<Input
+						id="race-date"
+						type="date"
+						value={selectedRaceDate}
+						className="w-48"
+						onChange={(e) => onRaceDateChange(e.target.value)}
+					/>
+				</div>
+
+				<div className="space-y-2">
+					<Label htmlFor="race-number">レース番号</Label>
+					<div className="space-y-2">
+						<Input
+							id="race-number"
+							type="number"
+							min={1}
+							max={12}
+							value={selectedRaceNumber}
+							className="h-8 w-16 text-center"
+							aria-label="レース番号を直接入力"
+							onChange={(e) => {
+								const n = Number.parseInt(e.target.value, 10);
+								if (n >= 1 && n <= 12) onRaceNumberChange(n);
+							}}
+						/>
+						<div className="flex flex-wrap gap-1.5">
+							{Array.from({ length: 12 }, (_, i) => i + 1).map((r) => (
+								<Button
+									key={r}
+									type="button"
+									variant={r === selectedRaceNumber ? "default" : "outline"}
+									size="sm"
+									aria-pressed={r === selectedRaceNumber}
+									className="w-10"
+									onClick={() => onRaceNumberChange(r)}
+								>
+									{r}R
+								</Button>
+							))}
+						</div>
+					</div>
+				</div>
+			</div>
+		</Section>
+	);
+}

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/RaceInfoSection/types.ts
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/RaceInfoSection/types.ts
@@ -1,0 +1,8 @@
+export type RaceInfoSectionProps = {
+	selectedVenue: string;
+	selectedRaceDate: string;
+	selectedRaceNumber: number;
+	onVenueChange: (venue: string) => void;
+	onRaceDateChange: (date: string) => void;
+	onRaceNumberChange: (num: number) => void;
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketTypeSelector/TicketTypeSelector.stories.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketTypeSelector/TicketTypeSelector.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TicketTypeSelector } from ".";
+
+const meta: Meta<typeof TicketTypeSelector> = {
+	title: "features/ticket/TicketTypeSelector",
+	component: TicketTypeSelector,
+};
+
+export default meta;
+type Story = StoryObj<typeof TicketTypeSelector>;
+
+export const Tansho: Story = {
+	name: "単勝・通常",
+	args: {
+		selectedTicketTypeId: "tansho",
+		selectedBuyTypeId: "single",
+		onTicketTypeChange: () => {},
+		onBuyTypeChange: () => {},
+	},
+};
+
+export const UmarenNagashi: Story = {
+	name: "馬連・流し",
+	args: {
+		selectedTicketTypeId: "umaren",
+		selectedBuyTypeId: "nagashi",
+		onTicketTypeChange: () => {},
+		onBuyTypeChange: () => {},
+	},
+};
+
+export const SanrenpukuFormation: Story = {
+	name: "三連複・フォーメーション",
+	args: {
+		selectedTicketTypeId: "sanrenpuku",
+		selectedBuyTypeId: "formation",
+		onTicketTypeChange: () => {},
+		onBuyTypeChange: () => {},
+	},
+};
+
+export const SanrentanNagashi: Story = {
+	name: "三連単・流し",
+	args: {
+		selectedTicketTypeId: "sanrentan",
+		selectedBuyTypeId: "nagashi",
+		onTicketTypeChange: () => {},
+		onBuyTypeChange: () => {},
+	},
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketTypeSelector/TicketTypeSelector.unit.test.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketTypeSelector/TicketTypeSelector.unit.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TicketTypeSelector } from ".";
+import { BUY_TYPE_MAP, TICKET_TYPES } from "../constants";
+import type { TicketTypeSelectorProps } from "./types";
+
+const noop = () => {};
+
+const baseProps: TicketTypeSelectorProps = {
+	selectedTicketTypeId: "umaren",
+	selectedBuyTypeId: "nagashi",
+	onTicketTypeChange: noop,
+	onBuyTypeChange: noop,
+};
+
+describe("TicketTypeSelector", () => {
+	describe("レンダリング", () => {
+		it("8種類の券種ボタンがすべて表示される", () => {
+			// Act
+			render(<TicketTypeSelector {...baseProps} />);
+
+			// Assert
+			expect(TICKET_TYPES).toHaveLength(8);
+			for (const { label } of TICKET_TYPES) {
+				expect(
+					screen.getByRole("button", { name: label }),
+				).toBeInTheDocument();
+			}
+		});
+
+		it("selectedTicketTypeId に対応する買い方ボタンが表示される", () => {
+			// Act
+			render(
+				<TicketTypeSelector
+					{...baseProps}
+					selectedTicketTypeId="umatan"
+					selectedBuyTypeId="nagashi"
+				/>,
+			);
+
+			// Assert
+			const buyTypes = BUY_TYPE_MAP.umatan;
+			for (const { label } of buyTypes) {
+				expect(
+					screen.getByRole("button", { name: label }),
+				).toBeInTheDocument();
+			}
+		});
+	});
+
+	describe("選択状態の表示", () => {
+		it("selectedTicketTypeId に対応する券種ボタンのみ aria-pressed=true になる", () => {
+			// Act
+			render(
+				<TicketTypeSelector
+					{...baseProps}
+					selectedTicketTypeId="sanrenpuku"
+				/>,
+			);
+
+			// Assert
+			for (const { id, label } of TICKET_TYPES) {
+				const button = screen.getByRole("button", { name: label });
+				if (id === "sanrenpuku") {
+					expect(button).toHaveAttribute("aria-pressed", "true");
+				} else {
+					expect(button).toHaveAttribute("aria-pressed", "false");
+				}
+			}
+		});
+
+		it("selectedBuyTypeId に対応する買い方ボタンのみ aria-pressed=true になる", () => {
+			// Act
+			render(
+				<TicketTypeSelector
+					{...baseProps}
+					selectedTicketTypeId="umatan"
+					selectedBuyTypeId="box"
+				/>,
+			);
+
+			// Assert
+			const buyTypes = BUY_TYPE_MAP.umatan;
+			for (const { id, label } of buyTypes) {
+				const button = screen.getByRole("button", { name: label });
+				if (id === "box") {
+					expect(button).toHaveAttribute("aria-pressed", "true");
+				} else {
+					expect(button).toHaveAttribute("aria-pressed", "false");
+				}
+			}
+		});
+	});
+});

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketTypeSelector/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketTypeSelector/index.tsx
@@ -1,0 +1,51 @@
+import { Button } from "@/components/shadcn/ui/button";
+import { BUY_TYPE_MAP, TICKET_TYPES } from "../constants";
+import { Section } from "../Section";
+import type { TicketTypeSelectorProps } from "./types";
+
+export function TicketTypeSelector({
+	selectedTicketTypeId,
+	selectedBuyTypeId,
+	onTicketTypeChange,
+	onBuyTypeChange,
+}: TicketTypeSelectorProps) {
+	const buyTypes = BUY_TYPE_MAP[selectedTicketTypeId];
+
+	return (
+		<>
+			<Section title="券種">
+				<div className="flex flex-wrap gap-2">
+					{TICKET_TYPES.map(({ id, label }) => (
+						<Button
+							key={id}
+							type="button"
+							variant={id === selectedTicketTypeId ? "default" : "outline"}
+							size="sm"
+							aria-pressed={id === selectedTicketTypeId}
+							onClick={() => onTicketTypeChange(id)}
+						>
+							{label}
+						</Button>
+					))}
+				</div>
+			</Section>
+
+			<Section title="買い方">
+				<div className="flex flex-wrap gap-2">
+					{buyTypes.map(({ id, label }) => (
+						<Button
+							key={id}
+							type="button"
+							variant={id === selectedBuyTypeId ? "default" : "outline"}
+							size="sm"
+							aria-pressed={id === selectedBuyTypeId}
+							onClick={() => onBuyTypeChange(id)}
+						>
+							{label}
+						</Button>
+					))}
+				</div>
+			</Section>
+		</>
+	);
+}

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketTypeSelector/types.ts
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketTypeSelector/types.ts
@@ -1,0 +1,8 @@
+import type { TicketTypeId } from "../constants";
+
+export type TicketTypeSelectorProps = {
+	selectedTicketTypeId: TicketTypeId;
+	selectedBuyTypeId: string;
+	onTicketTypeChange: (id: TicketTypeId) => void;
+	onBuyTypeChange: (id: string) => void;
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/index.tsx
@@ -1,24 +1,10 @@
 import { Button } from "@/components/shadcn/ui/button";
 import { Input } from "@/components/shadcn/ui/input";
-import { Label } from "@/components/shadcn/ui/label";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/shadcn/ui/select";
-import {
-	BUY_TYPE_MAP,
-	GRID_SIZE,
-	HORSE_INPUT_CONFIG,
-	TICKET_TYPES,
-	VENUES,
-} from "./constants";
-import { HorseGrid } from "./HorseGrid";
+import { HorseSelectionSection } from "./HorseSelectionSection";
+import { RaceInfoSection } from "./RaceInfoSection";
 import { Section } from "./Section";
+import { TicketTypeSelector } from "./TicketTypeSelector";
 import type { TicketPurchaseFormProps } from "./types";
-import { getHorseInputConfigKey } from "./utils";
 
 // テストファイルおよびStorybookから./indexを参照しているため、互換性のためにre-exportする
 export { TICKET_TYPES, BUY_TYPE_MAP } from "./constants";
@@ -47,206 +33,34 @@ export default function TicketPurchaseForm({
 	onHorsesChange,
 	onAmountChange,
 }: TicketPurchaseFormProps) {
-	const buyTypes = BUY_TYPE_MAP[selectedTicketTypeId];
-	const gridSize = GRID_SIZE[selectedTicketTypeId] ?? 18;
-
-	// 三連複nagashiのみ軸頭数を選択できる
-	const showAxisCountSelector =
-		selectedBuyTypeId === "nagashi" && selectedTicketTypeId === "sanrenpuku";
-
-	// 三連単nagashiのみ流し方向を選択できる
-	const showNagashiDirectionSelector =
-		selectedBuyTypeId === "nagashi" && selectedTicketTypeId === "sanrentan";
-
-	const horseInputConfigKey = getHorseInputConfigKey(
-		selectedTicketTypeId,
-		selectedBuyTypeId,
-		selectedAxisCount,
-		selectedNagashiDirection,
-	);
-
-	const horseGroups = HORSE_INPUT_CONFIG[horseInputConfigKey] ?? [];
-
-	const handleHorseToggle = (groupKey: string, num: number) => {
-		const current = selectedHorses[groupKey] ?? [];
-		const next = current.includes(num)
-			? current.filter((n) => n !== num)
-			: [...current, num];
-		onHorsesChange(groupKey, next);
-	};
-
-	const handleHorseTextChange = (groupKey: string, text: string) => {
-		const nums = text
-			.split(/[\s,]+/)
-			.map(Number)
-			.filter((n) => Number.isInteger(n) && n >= 1 && n <= gridSize);
-		onHorsesChange(groupKey, nums);
-	};
-
 	return (
 		<div className="mx-auto max-w-2xl space-y-8 p-4">
-			{/* 1. レース情報 */}
-			<Section title="レース情報">
-				<div className="space-y-4">
-					<div className="space-y-2">
-						<Label htmlFor="venue">開催場所</Label>
-						<Select value={selectedVenue} onValueChange={onVenueChange}>
-							<SelectTrigger id="venue" className="w-40">
-								<SelectValue placeholder="選択してください" />
-							</SelectTrigger>
-							<SelectContent>
-								{VENUES.map((venue) => (
-									<SelectItem key={venue} value={venue}>
-										{venue}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</div>
+			<RaceInfoSection
+				selectedVenue={selectedVenue}
+				selectedRaceDate={selectedRaceDate}
+				selectedRaceNumber={selectedRaceNumber}
+				onVenueChange={onVenueChange}
+				onRaceDateChange={onRaceDateChange}
+				onRaceNumberChange={onRaceNumberChange}
+			/>
 
-					<div className="space-y-2">
-						<Label htmlFor="race-date">開催日</Label>
-						<Input
-							id="race-date"
-							type="date"
-							value={selectedRaceDate}
-							className="w-48"
-							onChange={(e) => onRaceDateChange(e.target.value)}
-						/>
-					</div>
+			<TicketTypeSelector
+				selectedTicketTypeId={selectedTicketTypeId}
+				selectedBuyTypeId={selectedBuyTypeId}
+				onTicketTypeChange={onTicketTypeChange}
+				onBuyTypeChange={onBuyTypeChange}
+			/>
 
-					<div className="space-y-2">
-						<Label htmlFor="race-number">レース番号</Label>
-						<div className="space-y-2">
-							<Input
-								id="race-number"
-								type="number"
-								min={1}
-								max={12}
-								value={selectedRaceNumber}
-								className="h-8 w-16 text-center"
-								aria-label="レース番号を直接入力"
-								onChange={(e) => {
-									const n = Number.parseInt(e.target.value, 10);
-									if (n >= 1 && n <= 12) onRaceNumberChange(n);
-								}}
-							/>
-							<div className="flex flex-wrap gap-1.5">
-								{Array.from({ length: 12 }, (_, i) => i + 1).map((r) => (
-									<Button
-										key={r}
-										type="button"
-										variant={r === selectedRaceNumber ? "default" : "outline"}
-										size="sm"
-										aria-pressed={r === selectedRaceNumber}
-										className="w-10"
-										onClick={() => onRaceNumberChange(r)}
-									>
-										{r}R
-									</Button>
-								))}
-							</div>
-						</div>
-					</div>
-				</div>
-			</Section>
-
-			{/* 2. 券種選択 */}
-			<Section title="券種">
-				<div className="flex flex-wrap gap-2">
-					{TICKET_TYPES.map(({ id, label }) => (
-						<Button
-							key={id}
-							type="button"
-							variant={id === selectedTicketTypeId ? "default" : "outline"}
-							size="sm"
-							aria-pressed={id === selectedTicketTypeId}
-							onClick={() => onTicketTypeChange(id)}
-						>
-							{label}
-						</Button>
-					))}
-				</div>
-			</Section>
-
-			{/* 3. 買い方選択 */}
-			<Section title="買い方">
-				<div className="flex flex-wrap gap-2">
-					{buyTypes.map(({ id, label }) => (
-						<Button
-							key={id}
-							type="button"
-							variant={id === selectedBuyTypeId ? "default" : "outline"}
-							size="sm"
-							aria-pressed={id === selectedBuyTypeId}
-							onClick={() => onBuyTypeChange(id)}
-						>
-							{label}
-						</Button>
-					))}
-				</div>
-			</Section>
-
-			{/* 4. 馬番入力 */}
-			<Section title="馬番">
-				<div className="space-y-6">
-					{/* 三連複nagashiのみ：軸頭数セレクター */}
-					{showAxisCountSelector && (
-						<div className="space-y-2">
-							<Label>軸の頭数</Label>
-							<div className="flex gap-2">
-								{([1, 2] as const).map((count) => (
-									<Button
-										key={count}
-										type="button"
-										variant={
-											count === selectedAxisCount ? "default" : "outline"
-										}
-										size="sm"
-										aria-pressed={count === selectedAxisCount}
-										onClick={() => onAxisCountChange(count)}
-									>
-										{count}頭軸
-									</Button>
-								))}
-							</div>
-						</div>
-					)}
-					{/* 三連単nagashiのみ：流し方向セレクター */}
-					{showNagashiDirectionSelector && (
-						<div className="space-y-2">
-							<Label>流し方向</Label>
-							<div className="flex gap-2">
-								{([1, 2, 3] as const).map((pos) => (
-									<Button
-										key={pos}
-										type="button"
-										variant={
-											pos === selectedNagashiDirection ? "default" : "outline"
-										}
-										size="sm"
-										aria-pressed={pos === selectedNagashiDirection}
-										onClick={() => onNagashiDirectionChange(pos)}
-									>
-										{pos}着流し
-									</Button>
-								))}
-							</div>
-						</div>
-					)}
-					{horseGroups.map(({ key, label }) => (
-						<HorseGrid
-							key={key}
-							groupKey={key}
-							label={label}
-							gridSize={gridSize}
-							selectedHorses={selectedHorses[key] ?? []}
-							onToggle={(num) => handleHorseToggle(key, num)}
-							onTextChange={(text) => handleHorseTextChange(key, text)}
-						/>
-					))}
-				</div>
-			</Section>
+			<HorseSelectionSection
+				selectedTicketTypeId={selectedTicketTypeId}
+				selectedBuyTypeId={selectedBuyTypeId}
+				selectedAxisCount={selectedAxisCount}
+				selectedNagashiDirection={selectedNagashiDirection}
+				selectedHorses={selectedHorses}
+				onAxisCountChange={onAxisCountChange}
+				onNagashiDirectionChange={onNagashiDirectionChange}
+				onHorsesChange={onHorsesChange}
+			/>
 
 			{/* 5. 金額入力 */}
 			<Section title="金額">


### PR DESCRIPTION
## やったこと

- `TicketPurchaseForm` を3つのサブコンポーネントに分割し、可読性・保守性を向上させた
  - `HorseSelectionSection`: 出走馬選択セクション
  - `RaceInfoSection`: レース情報セクション
  - `TicketTypeSelector`: 馬券種別選択
- 各サブコンポーネントに Storybook と単体テストを追加した
- `TicketPurchaseForm/index.tsx` をサブコンポーネントを組み合わせる形に書き換えた（244行 → 約30行）

## 結果

リファクタリングのため UI の見た目に変化はなし

## 動作確認済み

- [ ] 既存の TicketPurchaseForm の動作が変わっていないこと