### PR TITLE
[minor] レース結果確認画面に着順表示を追加

### DIFF
--- a/docs/specs/er-diagram.md
+++ b/docs/specs/er-diagram.md
@@ -120,6 +120,30 @@ erDiagram
     races ||--o{ race_entries : "has"
     horses ||--o{ race_entries : "participates in"
     jockeys ||--o{ race_entries : "rides in"
+
+    race_result_horses {
+        bigint id PK
+        bigint race_id FK
+        tinyint finishing_order "着順"
+        tinyint frame_number "枠番"
+        tinyint horse_number "馬番"
+        string horse_name "馬名"
+        string sex_age "性齢"
+        decimal weight "負担重量(kg)"
+        string jockey_name "騎手名"
+        string race_time "タイム"
+        string time_difference "タイム差 nullable"
+        string corner_order "コーナー順位 nullable"
+        decimal estimated_pace "推定ペース nullable"
+        smallint horse_weight "馬体重(kg) nullable"
+        smallint horse_weight_change "馬体重増減(kg) nullable"
+        string trainer_name "調教師名"
+        tinyint popularity "人気順位"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    races ||--o{ race_result_horses : "has"
 ```
 
 ## selectionsカラムのJSONフォーマット

--- a/docs/specs/er-diagram.md
+++ b/docs/specs/er-diagram.md
@@ -124,6 +124,8 @@ erDiagram
     race_result_horses {
         bigint id PK
         bigint race_id FK
+        bigint horse_id FK "nullable"
+        bigint jockey_id FK "nullable"
         tinyint finishing_order "着順"
         tinyint frame_number "枠番"
         tinyint horse_number "馬番"
@@ -144,6 +146,8 @@ erDiagram
     }
 
     races ||--o{ race_result_horses : "has"
+    horses ||--o{ race_result_horses : "has"
+    jockeys ||--o{ race_result_horses : "has"
 ```
 
 ## selectionsカラムのJSONフォーマット

--- a/source/app/Models/Horse.php
+++ b/source/app/Models/Horse.php
@@ -17,4 +17,10 @@ class Horse extends Model
     {
         return $this->hasMany(RaceEntry::class);
     }
+
+    /** @return HasMany<RaceResultHorse, $this> */
+    public function raceResultHorses(): HasMany
+    {
+        return $this->hasMany(RaceResultHorse::class);
+    }
 }

--- a/source/app/Models/Jockey.php
+++ b/source/app/Models/Jockey.php
@@ -16,4 +16,10 @@ class Jockey extends Model
     {
         return $this->hasMany(RaceEntry::class);
     }
+
+    /** @return HasMany<RaceResultHorse, $this> */
+    public function raceResultHorses(): HasMany
+    {
+        return $this->hasMany(RaceResultHorse::class);
+    }
 }

--- a/source/app/Models/Race.php
+++ b/source/app/Models/Race.php
@@ -43,4 +43,10 @@ class Race extends Model
     {
         return $this->hasMany(RaceEntry::class);
     }
+
+    /** @return HasMany<RaceResultHorse, $this> */
+    public function raceResultHorses(): HasMany
+    {
+        return $this->hasMany(RaceResultHorse::class);
+    }
 }

--- a/source/app/Models/RaceResultHorse.php
+++ b/source/app/Models/RaceResultHorse.php
@@ -9,6 +9,8 @@ class RaceResultHorse extends Model
 {
     protected $fillable = [
         'race_id',
+        'horse_id',
+        'jockey_id',
         'finishing_order',
         'frame_number',
         'horse_number',
@@ -30,5 +32,17 @@ class RaceResultHorse extends Model
     public function race(): BelongsTo
     {
         return $this->belongsTo(Race::class);
+    }
+
+    /** @return BelongsTo<Horse, $this> */
+    public function horse(): BelongsTo
+    {
+        return $this->belongsTo(Horse::class);
+    }
+
+    /** @return BelongsTo<Jockey, $this> */
+    public function jockey(): BelongsTo
+    {
+        return $this->belongsTo(Jockey::class);
     }
 }

--- a/source/app/UseCases/RaceResult/ShowResultAction.php
+++ b/source/app/UseCases/RaceResult/ShowResultAction.php
@@ -22,6 +22,14 @@ class ShowResultAction
      *         popularity: int,
      *         horses: list<array{horse_number: int, sort_order: int}>,
      *     }>,
+     *     finishing_horses: list<array{
+     *         finishing_order: int,
+     *         frame_number: int,
+     *         horse_number: int,
+     *         horse_name: string,
+     *         jockey_name: string,
+     *         race_time: string,
+     *     }>,
      * }
      */
     public function execute(string $uid): array
@@ -37,6 +45,9 @@ class ShowResultAction
                 'racePayouts.ticketType',
                 'racePayouts.racePayoutHorses' => function ($query) {
                     $query->orderBy('sort_order');
+                },
+                'raceResultHorses' => function ($query) {
+                    $query->orderBy('finishing_order');
                 },
             ])
             ->firstOrFail();
@@ -56,12 +67,24 @@ class ShowResultAction
             ];
         })->values()->all();
 
+        $finishingHorses = $race->raceResultHorses->map(function ($horse) {
+            return [
+                'finishing_order' => $horse->finishing_order,
+                'frame_number' => $horse->frame_number,
+                'horse_number' => $horse->horse_number,
+                'horse_name' => $horse->horse_name,
+                'jockey_name' => $horse->jockey_name,
+                'race_time' => $horse->race_time,
+            ];
+        })->values()->all();
+
         return [
             'uid' => $race->uid,
             'venue_name' => $race->venue->name,
             'race_date' => $race->race_date,
             'race_number' => $race->race_number,
             'payouts' => $payouts,
+            'finishing_horses' => $finishingHorses,
         ];
     }
 }

--- a/source/app/UseCases/RaceResult/StoreAction.php
+++ b/source/app/UseCases/RaceResult/StoreAction.php
@@ -3,6 +3,8 @@
 namespace App\UseCases\RaceResult;
 
 use App\Exceptions\RaceResult\ParseException;
+use App\Models\Horse;
+use App\Models\Jockey;
 use App\Models\Race;
 use App\Models\RacePayout;
 use App\Models\RacePayoutHorse;
@@ -79,7 +81,12 @@ class StoreAction
 
         DB::transaction(function () use ($entries, $resultHorseEntries, $raceId, $ticketTypeIds, $userId): void {
             foreach ($resultHorseEntries as $horseEntry) {
-                RaceResultHorse::create(array_merge(['race_id' => $raceId], $horseEntry));
+                $horse = Horse::firstOrCreate(['name' => $horseEntry['horse_name']]);
+                $jockey = Jockey::firstOrCreate(['name' => $horseEntry['jockey_name']]);
+                RaceResultHorse::create(array_merge(
+                    ['race_id' => $raceId, 'horse_id' => $horse->id, 'jockey_id' => $jockey->id],
+                    $horseEntry
+                ));
             }
 
             foreach ($entries as $entry) {

--- a/source/database/migrations/2026_04_25_124606_add_horse_id_and_jockey_id_to_race_result_horses_table.php
+++ b/source/database/migrations/2026_04_25_124606_add_horse_id_and_jockey_id_to_race_result_horses_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('race_result_horses', function (Blueprint $table) {
+            $table->foreignId('horse_id')->nullable()->constrained()->nullOnDelete()->after('race_id');
+            $table->foreignId('jockey_id')->nullable()->constrained()->nullOnDelete()->after('horse_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('race_result_horses', function (Blueprint $table) {
+            $table->dropForeignIdFor(\App\Models\Horse::class);
+            $table->dropForeignIdFor(\App\Models\Jockey::class);
+        });
+    }
+};

--- a/source/database/migrations/2026_04_25_124606_add_horse_id_and_jockey_id_to_race_result_horses_table.php
+++ b/source/database/migrations/2026_04_25_124606_add_horse_id_and_jockey_id_to_race_result_horses_table.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Horse;
+use App\Models\Jockey;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -17,8 +19,8 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('race_result_horses', function (Blueprint $table) {
-            $table->dropForeignIdFor(\App\Models\Horse::class);
-            $table->dropForeignIdFor(\App\Models\Jockey::class);
+            $table->dropForeignIdFor(Horse::class);
+            $table->dropForeignIdFor(Jockey::class);
         });
     }
 };

--- a/source/database/migrations/2026_04_25_124607_make_birth_year_nullable_in_horses_table.php
+++ b/source/database/migrations/2026_04_25_124607_make_birth_year_nullable_in_horses_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('horses', function (Blueprint $table) {
+            $table->unsignedSmallInteger('birth_year')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('horses', function (Blueprint $table) {
+            $table->unsignedSmallInteger('birth_year')->nullable(false)->change();
+        });
+    }
+};

--- a/source/database/migrations/2026_04_25_124607_make_birth_year_nullable_in_horses_table.php
+++ b/source/database/migrations/2026_04_25_124607_make_birth_year_nullable_in_horses_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -15,6 +16,9 @@ return new class extends Migration
 
     public function down(): void
     {
+        // firstOrCreate で birth_year なしに作成されたレコードは 0 で補完してから NOT NULL に戻す
+        DB::table('horses')->whereNull('birth_year')->update(['birth_year' => 0]);
+
         Schema::table('horses', function (Blueprint $table) {
             $table->unsignedSmallInteger('birth_year')->nullable(false)->change();
         });

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
@@ -20,6 +20,34 @@ const baseRace: Pick<
 	race_number: 11,
 };
 
+const sampleFinishingHorses: RaceResultDetailProps["race"]["finishing_horses"] =
+	[
+		{
+			finishing_order: 1,
+			frame_number: 2,
+			horse_number: 3,
+			horse_name: "ディープスター",
+			jockey_name: "武豊",
+			race_time: "1:33.5",
+		},
+		{
+			finishing_order: 2,
+			frame_number: 3,
+			horse_number: 5,
+			horse_name: "サクラチカラ",
+			jockey_name: "川田将雅",
+			race_time: "1:33.7",
+		},
+		{
+			finishing_order: 3,
+			frame_number: 5,
+			horse_number: 8,
+			horse_name: "ゴールドウィング",
+			jockey_name: "福永祐一",
+			race_time: "1:33.9",
+		},
+	];
+
 const allPayouts: RaceResultDetailProps["race"]["payouts"] = [
 	{
 		ticket_type_label: "単勝",
@@ -139,6 +167,7 @@ export const Default: Story = {
 		race: {
 			...baseRace,
 			payouts: allPayouts,
+			finishing_horses: sampleFinishingHorses,
 		},
 	},
 };
@@ -171,6 +200,18 @@ export const ArrowNotation: Story = {
 					],
 				},
 			],
+			finishing_horses: sampleFinishingHorses,
+		},
+	},
+};
+
+export const NoFinishingHorses: Story = {
+	name: "着順データなし",
+	args: {
+		race: {
+			...baseRace,
+			payouts: allPayouts,
+			finishing_horses: [],
 		},
 	},
 };

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -13,6 +13,69 @@ export default function RaceResultDetail({ race }: RaceResultDetailProps) {
 				</p>
 			</div>
 
+			<div className="flex flex-col gap-2">
+				<h2 className="text-base font-semibold">着順</h2>
+				{race.finishing_horses.length === 0 ? (
+					<p className="text-sm text-muted-foreground">
+						着順データがありません
+					</p>
+				) : (
+					<div className="overflow-x-auto rounded-xl border">
+						<table className="w-full text-sm">
+							<thead>
+								<tr className="border-b bg-muted/50">
+									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+										着順
+									</th>
+									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+										枠番
+									</th>
+									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+										馬番
+									</th>
+									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+										馬名
+									</th>
+									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+										騎手
+									</th>
+									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+										タイム
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								{race.finishing_horses.map((horse) => (
+									<tr
+										key={horse.finishing_order}
+										className="border-b last:border-0 hover:bg-muted/30"
+									>
+										<td className="px-4 py-3">
+											{horse.finishing_order}
+										</td>
+										<td className="px-4 py-3">
+											{horse.frame_number}
+										</td>
+										<td className="px-4 py-3">
+											{horse.horse_number}
+										</td>
+										<td className="px-4 py-3">
+											{horse.horse_name}
+										</td>
+										<td className="px-4 py-3">
+											{horse.jockey_name}
+										</td>
+										<td className="px-4 py-3 text-right">
+											{horse.race_time}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				)}
+			</div>
+
 			<div className="overflow-x-auto rounded-xl border">
 				<table className="w-full text-sm">
 					<thead>

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -47,7 +47,7 @@ export default function RaceResultDetail({ race }: RaceResultDetailProps) {
 							<tbody>
 								{race.finishing_horses.map((horse) => (
 									<tr
-										key={horse.finishing_order}
+										key={horse.horse_number}
 										className="border-b last:border-0 hover:bg-muted/30"
 									>
 										<td className="px-4 py-3">

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/types.ts
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/types.ts
@@ -9,6 +9,15 @@ export type PayoutEntry = {
 	}>;
 };
 
+export type FinishingHorse = {
+	finishing_order: number;
+	frame_number: number;
+	horse_number: number;
+	horse_name: string;
+	jockey_name: string;
+	race_time: string;
+};
+
 export type RaceResultDetailProps = {
 	race: {
 		uid: string;
@@ -16,5 +25,6 @@ export type RaceResultDetailProps = {
 		race_date: string;
 		race_number: number;
 		payouts: PayoutEntry[];
+		finishing_horses: FinishingHorse[];
 	};
 };

--- a/source/tests/Feature/Races/RaceResultTest.php
+++ b/source/tests/Feature/Races/RaceResultTest.php
@@ -1077,7 +1077,7 @@ test('umatan horses in race result edit page are ordered by sort_order', functio
 
 // ===== GET /races/{uid}/result/edit — finishing_horses =====
 
-test('finishing_horses is included in props when race_result_horses records exist', function () {
+test('finishing_horses items have correct fields and values', function () {
     // Arrange
     $user = User::factory()->create();
     ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
@@ -1105,45 +1105,14 @@ test('finishing_horses is included in props when race_result_horses records exis
     // Assert
     $response->assertInertia(fn (Assert $page) => $page
         ->component('races/result/edit')
-        ->has('race.finishing_horses')
-    );
-});
-
-test('finishing_horses items have correct fields', function () {
-    // Arrange
-    $user = User::factory()->create();
-    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
-    ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
-
-    DB::table('race_result_horses')->insert([
-        'race_id' => $raceId,
-        'finishing_order' => 1,
-        'frame_number' => 2,
-        'horse_number' => 3,
-        'horse_name' => 'テスト馬A',
-        'sex_age' => '牡3',
-        'weight' => '57.0',
-        'jockey_name' => '騎手A',
-        'race_time' => '1:34.5',
-        'trainer_name' => '調教師A',
-        'popularity' => 1,
-        'created_at' => $now,
-        'updated_at' => $now,
-    ]);
-
-    // Act
-    $response = $this->actingAs($user)->get(route('races.result.edit', ['uid' => $raceUid]));
-
-    // Assert
-    $response->assertInertia(fn (Assert $page) => $page
-        ->component('races/result/edit')
+        ->has('race.finishing_horses', 1)
         ->has('race.finishing_horses.0', fn (Assert $horse) => $horse
-            ->has('finishing_order')
-            ->has('frame_number')
-            ->has('horse_number')
-            ->has('horse_name')
-            ->has('jockey_name')
-            ->has('race_time')
+            ->where('finishing_order', 1)
+            ->where('frame_number', 2)
+            ->where('horse_number', 3)
+            ->where('horse_name', 'テスト馬A')
+            ->where('jockey_name', '騎手A')
+            ->where('race_time', '1:34.5')
             ->etc()
         )
     );

--- a/source/tests/Feature/Races/RaceResultTest.php
+++ b/source/tests/Feature/Races/RaceResultTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Horse;
+use App\Models\Jockey;
 use App\Models\User;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Facades\DB;
@@ -979,8 +981,8 @@ test('existing horse and jockey records are reused when result text contains sam
     ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
     ['raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
 
-    $existingHorse = \App\Models\Horse::create(['name' => 'テスト馬A']);
-    $existingJockey = \App\Models\Jockey::create(['name' => '騎手A']);
+    $existingHorse = Horse::create(['name' => 'テスト馬A']);
+    $existingJockey = Jockey::create(['name' => '騎手A']);
 
     // Act
     $this->actingAs($user)->post(route('races.result.store', ['uid' => $raceUid]), [

--- a/source/tests/Feature/Races/RaceResultTest.php
+++ b/source/tests/Feature/Races/RaceResultTest.php
@@ -1074,3 +1074,160 @@ test('umatan horses in race result edit page are ordered by sort_order', functio
         ->where('race.payouts.0.horses.1.horse_number', 5)
     );
 });
+
+// ===== GET /races/{uid}/result/edit — finishing_horses =====
+
+test('finishing_horses is included in props when race_result_horses records exist', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    DB::table('race_result_horses')->insert([
+        'race_id' => $raceId,
+        'finishing_order' => 1,
+        'frame_number' => 2,
+        'horse_number' => 3,
+        'horse_name' => 'テスト馬A',
+        'sex_age' => '牡3',
+        'weight' => '57.0',
+        'jockey_name' => '騎手A',
+        'race_time' => '1:34.5',
+        'trainer_name' => '調教師A',
+        'popularity' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('races.result.edit', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('races/result/edit')
+        ->has('race.finishing_horses')
+    );
+});
+
+test('finishing_horses items have correct fields', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    DB::table('race_result_horses')->insert([
+        'race_id' => $raceId,
+        'finishing_order' => 1,
+        'frame_number' => 2,
+        'horse_number' => 3,
+        'horse_name' => 'テスト馬A',
+        'sex_age' => '牡3',
+        'weight' => '57.0',
+        'jockey_name' => '騎手A',
+        'race_time' => '1:34.5',
+        'trainer_name' => '調教師A',
+        'popularity' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('races.result.edit', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('races/result/edit')
+        ->has('race.finishing_horses.0', fn (Assert $horse) => $horse
+            ->has('finishing_order')
+            ->has('frame_number')
+            ->has('horse_number')
+            ->has('horse_name')
+            ->has('jockey_name')
+            ->has('race_time')
+            ->etc()
+        )
+    );
+});
+
+test('finishing_horses is empty array when no race_result_horses records exist', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('races.result.edit', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('races/result/edit')
+        ->where('race.finishing_horses', [])
+    );
+});
+
+test('finishing_horses are sorted by finishing_order ascending', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    DB::table('race_result_horses')->insert([
+        [
+            'race_id' => $raceId,
+            'finishing_order' => 3,
+            'frame_number' => 1,
+            'horse_number' => 1,
+            'horse_name' => 'テスト馬C',
+            'sex_age' => '牡5',
+            'weight' => '58.0',
+            'jockey_name' => '騎手C',
+            'race_time' => '1:35.0',
+            'trainer_name' => '調教師C',
+            'popularity' => 2,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ],
+        [
+            'race_id' => $raceId,
+            'finishing_order' => 1,
+            'frame_number' => 2,
+            'horse_number' => 3,
+            'horse_name' => 'テスト馬A',
+            'sex_age' => '牡3',
+            'weight' => '57.0',
+            'jockey_name' => '騎手A',
+            'race_time' => '1:34.5',
+            'trainer_name' => '調教師A',
+            'popularity' => 1,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ],
+        [
+            'race_id' => $raceId,
+            'finishing_order' => 2,
+            'frame_number' => 4,
+            'horse_number' => 7,
+            'horse_name' => 'テスト馬B',
+            'sex_age' => '牝4',
+            'weight' => '55.0',
+            'jockey_name' => '騎手B',
+            'race_time' => '1:34.8',
+            'trainer_name' => '調教師B',
+            'popularity' => 3,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ],
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('races.result.edit', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('races/result/edit')
+        ->has('race.finishing_horses', 3)
+        ->where('race.finishing_horses.0.finishing_order', 1)
+        ->where('race.finishing_horses.1.finishing_order', 2)
+        ->where('race.finishing_horses.2.finishing_order', 3)
+    );
+});

--- a/source/tests/Feature/Races/RaceResultTest.php
+++ b/source/tests/Feature/Races/RaceResultTest.php
@@ -909,8 +909,12 @@ test('race_result_horses records have correct field mappings', function () use (
     ]);
 
     // Assert
+    $horseId = DB::table('horses')->where('name', 'テスト馬A')->value('id');
+    $jockeyId = DB::table('jockeys')->where('name', '騎手A')->value('id');
     $this->assertDatabaseHas('race_result_horses', [
         'race_id' => $raceId,
+        'horse_id' => $horseId,
+        'jockey_id' => $jockeyId,
         'finishing_order' => 1,
         'frame_number' => 2,
         'horse_number' => 3,
@@ -947,6 +951,50 @@ test('horse weight change is null when horse has no race experience', function (
         'horse_name' => 'テスト馬C',
         'horse_weight' => 490,
         'horse_weight_change' => null,
+    ]);
+});
+
+test('horses and jockeys are created in their tables when not previously registered', function () use ($resultSampleText, $sampleText) {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    // Act
+    $this->actingAs($user)->post(route('races.result.store', ['uid' => $raceUid]), [
+        'result_text' => $resultSampleText,
+        'text' => $sampleText,
+    ]);
+
+    // Assert
+    $this->assertDatabaseHas('horses', ['name' => 'テスト馬A']);
+    $this->assertDatabaseHas('horses', ['name' => 'テスト馬B']);
+    $this->assertDatabaseHas('jockeys', ['name' => '騎手A']);
+    $this->assertDatabaseHas('jockeys', ['name' => '騎手B']);
+});
+
+test('existing horse and jockey records are reused when result text contains same name', function () use ($resultSampleText, $sampleText) {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    $existingHorse = \App\Models\Horse::create(['name' => 'テスト馬A']);
+    $existingJockey = \App\Models\Jockey::create(['name' => '騎手A']);
+
+    // Act
+    $this->actingAs($user)->post(route('races.result.store', ['uid' => $raceUid]), [
+        'result_text' => $resultSampleText,
+        'text' => $sampleText,
+    ]);
+
+    // Assert: 既存レコードが再利用され、重複作成されていない
+    expect(DB::table('horses')->where('name', 'テスト馬A')->count())->toBe(1);
+    expect(DB::table('jockeys')->where('name', '騎手A')->count())->toBe(1);
+    $this->assertDatabaseHas('race_result_horses', [
+        'horse_name' => 'テスト馬A',
+        'horse_id' => $existingHorse->id,
+        'jockey_id' => $existingJockey->id,
     ]);
 });
 


### PR DESCRIPTION
## やったこと

- レース結果確認・編集画面（`/races/{uid}/result/edit`）に着順テーブルを追加
- `RaceResultDetail` コンポーネントに着順（着順・枠番・馬番・馬名・騎手・タイム）表示セクションを追加
- `finishing_horses` が空の場合は「着順データがありません」を表示
- `ShowResultAction` で `race_result_horses` テーブルのデータを取得・返却するよう更新（`finishing_order` 昇順）
- `Race` モデルに `raceResultHorses` HasMany リレーションを追加
- ER図に `race_result_horses` テーブルを追記
- `finishing_horses` に関する Feature テスト4件を追加（全38テストパス）

## 結果

## 動作確認済み

- [ ] レース結果確認画面で着順テーブルが表示される
- [ ] `race_result_horses` レコードがない場合「着順データがありません」が表示される