### PR TITLE
[minor] レース結果画面からレース結果入力画面への遷移と入力済み時のdisabled対応

### DIFF
--- a/source/app/UseCases/RaceResult/ShowAction.php
+++ b/source/app/UseCases/RaceResult/ShowAction.php
@@ -10,7 +10,7 @@ use App\Models\Race;
 class ShowAction
 {
     /**
-     * @return array{uid: string, venue_name: string, race_date: string, race_number: int}
+     * @return array{uid: string, venue_name: string, race_date: string, race_number: int, has_existing_result: bool}
      */
     public function execute(string $uid): array
     {
@@ -21,6 +21,7 @@ class ShowAction
             'venue_name' => $race->venue->name,
             'race_date' => $race->race_date,
             'race_number' => $race->race_number,
+            'has_existing_result' => $race->raceResultHorses()->exists(),
         ];
     }
 }

--- a/source/resources/js/features/raceResult/containers/RaceResultFormContainer/index.tsx
+++ b/source/resources/js/features/raceResult/containers/RaceResultFormContainer/index.tsx
@@ -7,6 +7,7 @@ type RaceResultFormContainerProps = {
 	venueName: string;
 	raceDate: string;
 	raceNumber: number;
+	disabled?: boolean;
 };
 
 type RaceResultFormData = {
@@ -19,6 +20,7 @@ export default function RaceResultFormContainer({
 	venueName,
 	raceDate,
 	raceNumber,
+	disabled,
 }: RaceResultFormContainerProps) {
 	const [resultPasteValue, setResultPasteValue] = useState("");
 	const [payoutPasteValue, setPayoutPasteValue] = useState("");
@@ -60,6 +62,7 @@ export default function RaceResultFormContainer({
 			payoutParseError={payoutParseError}
 			onSubmit={handleSubmit}
 			isSubmitting={isSubmitting}
+			disabled={disabled}
 		/>
 	);
 }

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/RaceResultDetail.unit.test.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/RaceResultDetail.unit.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import RaceResultDetail from "./index";
+
+vi.mock("@inertiajs/react", () => ({
+	Link: ({
+		href,
+		children,
+	}: {
+		href: string;
+		children: React.ReactNode;
+	}) => <a href={href}>{children}</a>,
+}));
+
+const baseProps = {
+	race: {
+		uid: "test-uid-123",
+		venue_name: "東京",
+		race_date: "2026-04-05",
+		race_number: 1,
+		payouts: [],
+		finishing_horses: [],
+	},
+};
+
+describe("RaceResultDetail", () => {
+	it("「レース結果入力」リンクが表示される", () => {
+		// Act
+		render(<RaceResultDetail {...baseProps} />);
+
+		// Assert
+		expect(
+			screen.getByRole("link", { name: "レース結果入力" }),
+		).toBeInTheDocument();
+	});
+
+	it("「レース結果入力」リンクのhrefにraceのuidを含む/result/newパスが設定されている", () => {
+		// Act
+		render(<RaceResultDetail {...baseProps} />);
+
+		// Assert
+		const link = screen.getByRole("link", { name: "レース結果入力" });
+		expect(link).toHaveAttribute(
+			"href",
+			"/races/test-uid-123/result/new",
+		);
+	});
+});

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/RaceResultDetail.unit.test.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/RaceResultDetail.unit.test.tsx
@@ -23,8 +23,17 @@ const baseProps = {
 	},
 };
 
+const sampleFinishingHorse = {
+	finishing_order: 1,
+	frame_number: 2,
+	horse_number: 3,
+	horse_name: "テスト馬A",
+	jockey_name: "騎手A",
+	race_time: "1:34.5",
+};
+
 describe("RaceResultDetail", () => {
-	it("「レース結果入力」リンクが表示される", () => {
+	it("着順データがないとき「レース結果入力」リンクが表示される", () => {
 		// Act
 		render(<RaceResultDetail {...baseProps} />);
 
@@ -34,7 +43,7 @@ describe("RaceResultDetail", () => {
 		).toBeInTheDocument();
 	});
 
-	it("「レース結果入力」リンクのhrefにraceのuidを含む/result/newパスが設定されている", () => {
+	it("着順データがないとき「レース結果入力」リンクのhrefにraceのuidを含む/result/newパスが設定されている", () => {
 		// Act
 		render(<RaceResultDetail {...baseProps} />);
 
@@ -44,5 +53,23 @@ describe("RaceResultDetail", () => {
 			"href",
 			"/races/test-uid-123/result/new",
 		);
+	});
+
+	it("着順データがあるとき「レース結果入力」リンクが表示されない", () => {
+		// Arrange
+		const props = {
+			race: {
+				...baseProps.race,
+				finishing_horses: [sampleFinishingHorse],
+			},
+		};
+
+		// Act
+		render(<RaceResultDetail {...props} />);
+
+		// Assert
+		expect(
+			screen.queryByRole("link", { name: "レース結果入力" }),
+		).not.toBeInTheDocument();
 	});
 });

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
@@ -206,12 +206,23 @@ export const ArrowNotation: Story = {
 };
 
 export const NoFinishingHorses: Story = {
-	name: "着順データなし",
+	name: "着順データなし（レース結果入力ボタン表示）",
 	args: {
 		race: {
 			...baseRace,
 			payouts: allPayouts,
 			finishing_horses: [],
+		},
+	},
+};
+
+export const InputButtonHidden: Story = {
+	name: "入力済み（レース結果入力ボタン非表示）",
+	args: {
+		race: {
+			...baseRace,
+			payouts: allPayouts,
+			finishing_horses: sampleFinishingHorses,
 		},
 	},
 };

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -15,11 +15,13 @@ export default function RaceResultDetail({ race }: RaceResultDetailProps) {
 						{race.race_number}R
 					</p>
 				</div>
-				<Button asChild variant="outline" size="sm">
-					<Link href={`/races/${race.uid}/result/new`}>
-						レース結果入力
-					</Link>
-				</Button>
+				{race.finishing_horses.length === 0 && (
+					<Button asChild variant="outline" size="sm">
+						<Link href={`/races/${race.uid}/result/new`}>
+							レース結果入力
+						</Link>
+					</Button>
+				)}
 			</div>
 
 			<div className="flex flex-col gap-2">

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -1,3 +1,5 @@
+import { Link } from "@inertiajs/react";
+import { Button } from "@/components/shadcn/ui/button";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceResultDetailProps } from "./types";
 import { formatHorseNumbers } from "./utils";
@@ -5,12 +7,19 @@ import { formatHorseNumbers } from "./utils";
 export default function RaceResultDetail({ race }: RaceResultDetailProps) {
 	return (
 		<div className="flex flex-col gap-4 p-4">
-			<div>
-				<h1 className="text-xl font-semibold">レース結果</h1>
-				<p className="text-sm text-muted-foreground">
-					{formatDateDisplay(race.race_date)} {race.venue_name}{" "}
-					{race.race_number}R
-				</p>
+			<div className="flex items-center justify-between">
+				<div>
+					<h1 className="text-xl font-semibold">レース結果</h1>
+					<p className="text-sm text-muted-foreground">
+						{formatDateDisplay(race.race_date)} {race.venue_name}{" "}
+						{race.race_number}R
+					</p>
+				</div>
+				<Button asChild variant="outline" size="sm">
+					<Link href={`/races/${race.uid}/result/new`}>
+						レース結果入力
+					</Link>
+				</Button>
 			</div>
 
 			<div className="flex flex-col gap-2">

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/RaceResultForm.unit.test.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/RaceResultForm.unit.test.tsx
@@ -156,6 +156,37 @@ describe("RaceResultForm", () => {
 			).not.toBeDisabled();
 		});
 
+		it("disabled=true のとき着順情報テキストエリアが disabled になる", () => {
+			// Act
+			render(<RaceResultForm {...baseProps} disabled={true} />);
+
+			// Assert
+			expect(screen.getByLabelText("着順情報をペースト")).toBeDisabled();
+		});
+
+		it("disabled=true のとき払い戻し情報テキストエリアが disabled になる", () => {
+			// Act
+			render(<RaceResultForm {...baseProps} disabled={true} />);
+
+			// Assert
+			expect(screen.getByLabelText("払い戻し情報をペースト")).toBeDisabled();
+		});
+
+		it("disabled=true かつ両テキストエリアに入力済みでも送信ボタンが disabled になる", () => {
+			// Act
+			render(
+				<RaceResultForm
+					{...baseProps}
+					resultPasteValue="some text"
+					payoutPasteValue="some text"
+					disabled={true}
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByRole("button", { name: "保存する" })).toBeDisabled();
+		});
+
 		it("isSubmitting が true のとき「保存中...」ボタンが表示され無効になる", () => {
 			// Act
 			render(

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/index.stories.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/index.stories.tsx
@@ -113,3 +113,15 @@ export const Submitting: Story = {
 		isSubmitting: true,
 	},
 };
+
+export const Disabled: Story = {
+	name: "入力済み（編集不可）",
+	args: {
+		...baseArgs,
+		resultPasteValue: resultMockData,
+		resultParseError: null,
+		payoutPasteValue: payoutMockData,
+		payoutParseError: null,
+		disabled: true,
+	},
+};

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
@@ -15,6 +15,7 @@ export default function RaceResultForm({
 	payoutParseError,
 	onSubmit,
 	isSubmitting,
+	disabled,
 }: RaceResultFormProps) {
 	return (
 		<div className="flex flex-col gap-6 p-4">
@@ -31,10 +32,11 @@ export default function RaceResultForm({
 				</label>
 				<textarea
 					id="result-paste-value"
-					className="min-h-[200px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+					className="min-h-[200px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:text-muted-foreground"
 					placeholder="JRA公式サイトの着順情報をコピー＆ペーストしてください"
 					value={resultPasteValue}
 					onChange={(e) => onResultPasteChange(e.target.value)}
+					disabled={disabled}
 				/>
 			</div>
 
@@ -51,10 +53,11 @@ export default function RaceResultForm({
 				</label>
 				<textarea
 					id="payout-paste-value"
-					className="min-h-[200px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+					className="min-h-[200px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:text-muted-foreground"
 					placeholder="JRA公式サイトの払い戻し情報をコピー＆ペーストしてください（単勝・複勝・枠連・ワイド・馬連・馬単・3連複・3連単の全券種が必要です）"
 					value={payoutPasteValue}
 					onChange={(e) => onPayoutPasteChange(e.target.value)}
+					disabled={disabled}
 				/>
 			</div>
 
@@ -70,7 +73,8 @@ export default function RaceResultForm({
 				disabled={
 					resultPasteValue.trim() === "" ||
 					payoutPasteValue.trim() === "" ||
-					isSubmitting
+					isSubmitting ||
+					disabled
 				}
 			>
 				{isSubmitting ? "保存中..." : "保存する"}

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/types.ts
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/types.ts
@@ -13,4 +13,5 @@ export type RaceResultFormProps = {
 	// 共通
 	onSubmit: () => void;
 	isSubmitting: boolean;
+	disabled?: boolean;
 };

--- a/source/resources/js/pages/races/result/create.tsx
+++ b/source/resources/js/pages/races/result/create.tsx
@@ -7,6 +7,7 @@ type RaceResultCreateProps = {
 		venue_name: string;
 		race_date: string;
 		race_number: number;
+		has_existing_result: boolean;
 	};
 };
 
@@ -21,6 +22,7 @@ export default function RaceResultCreate() {
 				venueName={race.venue_name}
 				raceDate={race.race_date}
 				raceNumber={race.race_number}
+				disabled={race.has_existing_result}
 			/>
 		</>
 	);

--- a/source/tests/Feature/Races/RaceResultTest.php
+++ b/source/tests/Feature/Races/RaceResultTest.php
@@ -159,6 +159,54 @@ test('accessing race result create page with non-existent uid returns 404', func
     $response->assertNotFound();
 });
 
+test('race result create page returns has_existing_result as false when no race result exists', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('races.result.create', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('races/result/create')
+        ->where('race.has_existing_result', false)
+    );
+});
+
+test('race result create page returns has_existing_result as true when race result exists', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    DB::table('race_result_horses')->insert([
+        'race_id' => $raceId,
+        'finishing_order' => 1,
+        'frame_number' => 2,
+        'horse_number' => 3,
+        'horse_name' => 'テスト馬A',
+        'sex_age' => '牡3',
+        'weight' => '57.0',
+        'jockey_name' => '騎手A',
+        'race_time' => '1:34.5',
+        'trainer_name' => '調教師A',
+        'popularity' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('races.result.create', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('races/result/create')
+        ->where('race.has_existing_result', true)
+    );
+});
+
 // ===== POST /races/{uid}/result =====
 
 test('valid payout text is stored with 8 race_payouts records', function () use ($sampleText, $resultSampleText) {


### PR DESCRIPTION
## やったこと

- レース結果確認画面に「レース結果入力」ボタンを追加し、`/races/{uid}/result/new` へ遷移できるようにした
- バックエンド（`ShowAction`）でレース結果の登録有無を `has_existing_result` として返すようにした
- レース結果が入力済みの場合、入力画面のテキストエリアと送信ボタンを disabled にした（disabled 時は文字色を `muted-foreground` で視覚的に区別）
- レース結果確認画面で着順データが既にある場合、「レース結果入力」ボタン自体を非表示にした
- 上記実装に対するテストを追加した（PHPテスト 2件、JSテスト 6件）

## 結果

スクリーンショット・動画なし

## 動作確認済み

- [ ] レース結果確認画面に「レース結果入力」ボタンが表示される
- [ ] ボタンから `/races/{uid}/result/new` へ遷移できる
- [ ] レース結果が未登録のレースでは入力できる
- [ ] レース結果が登録済みのレースではテキストエリアが disabled（灰色文字）になり、送信ボタンも disabled になる
- [ ] レース結果が登録済みのレースのレース結果確認画面では「レース結果入力」ボタンが表示されない