### PR TITLE
[minor] テーブルの横スクロール対応を共通コンポーネント化

### DIFF
--- a/source/resources/js/components/presentational/ScrollableTable/index.stories.tsx
+++ b/source/resources/js/components/presentational/ScrollableTable/index.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import ScrollableTable from ".";
+
+const meta: Meta<typeof ScrollableTable> = {
+	title: "components/presentational/ScrollableTable",
+	component: ScrollableTable,
+};
+
+export default meta;
+type Story = StoryObj<typeof ScrollableTable>;
+
+const sampleChildren = (
+	<>
+		<thead>
+			<tr className="border-b bg-muted/50">
+				<th className="px-4 py-3 text-left font-medium text-muted-foreground">日付</th>
+				<th className="px-4 py-3 text-left font-medium text-muted-foreground">レース場</th>
+				<th className="px-4 py-3 text-left font-medium text-muted-foreground">レース番号</th>
+				<th className="px-4 py-3 text-left font-medium text-muted-foreground">券種</th>
+				<th className="px-4 py-3 text-left font-medium text-muted-foreground">買い方</th>
+				<th className="px-4 py-3 text-right font-medium text-muted-foreground">購入金額</th>
+				<th className="px-4 py-3 text-right font-medium text-muted-foreground">払い戻し金額</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr className="border-b hover:bg-muted/30">
+				<td className="px-4 py-3">2026年4月5日</td>
+				<td className="px-4 py-3">東京競馬場</td>
+				<td className="px-4 py-3">11R</td>
+				<td className="px-4 py-3">三連単</td>
+				<td className="px-4 py-3">フォーメーション</td>
+				<td className="px-4 py-3 text-right">¥3,600</td>
+				<td className="px-4 py-3 text-right">¥12,500</td>
+			</tr>
+			<tr className="border-b hover:bg-muted/30">
+				<td className="px-4 py-3">2026年4月5日</td>
+				<td className="px-4 py-3">中山競馬場</td>
+				<td className="px-4 py-3">3R</td>
+				<td className="px-4 py-3">馬連</td>
+				<td className="px-4 py-3">流し</td>
+				<td className="px-4 py-3 text-right">¥300</td>
+				<td className="px-4 py-3 text-right">—</td>
+			</tr>
+		</tbody>
+	</>
+);
+
+export const Default: Story = {
+	name: "デフォルト",
+	args: {
+		children: sampleChildren,
+	},
+};
+
+export const Mobile: Story = {
+	name: "モバイル表示",
+	globals: {
+		viewport: { value: "mobile1", isRotated: false },
+	},
+	args: {
+		children: sampleChildren,
+	},
+};

--- a/source/resources/js/components/presentational/ScrollableTable/index.tsx
+++ b/source/resources/js/components/presentational/ScrollableTable/index.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+type Props = {
+	children: ReactNode;
+};
+
+export default function ScrollableTable({ children }: Props) {
+	return (
+		<div className="overflow-x-auto rounded-xl border">
+			<table className="w-full min-w-max text-sm">{children}</table>
+		</div>
+	);
+}

--- a/source/resources/js/components/presentational/ScrollableTable/index.unit.test.tsx
+++ b/source/resources/js/components/presentational/ScrollableTable/index.unit.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import ScrollableTable from "./index";
+
+describe("ScrollableTable", () => {
+	describe("children のレンダリング", () => {
+		it("渡された children が table 内にレンダリングされる", () => {
+			// Act
+			render(
+				<ScrollableTable>
+					<thead>
+						<tr>
+							<th>ヘッダー1</th>
+							<th>ヘッダー2</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>セル1</td>
+							<td>セル2</td>
+						</tr>
+					</tbody>
+				</ScrollableTable>,
+			);
+
+			// Assert
+			expect(screen.getByText("ヘッダー1")).toBeInTheDocument();
+			expect(screen.getByText("ヘッダー2")).toBeInTheDocument();
+			expect(screen.getByText("セル1")).toBeInTheDocument();
+			expect(screen.getByText("セル2")).toBeInTheDocument();
+		});
+	});
+
+	describe("ラッパー div のスタイル", () => {
+		it("ラッパー div に overflow-x-auto クラスが適用されている", () => {
+			// Act
+			render(
+				<ScrollableTable>
+					<tbody>
+						<tr>
+							<td>cell</td>
+						</tr>
+					</tbody>
+				</ScrollableTable>,
+			);
+
+			// Assert
+			const wrapper = screen.getByRole("table").parentElement;
+			expect(wrapper).toHaveClass("overflow-x-auto");
+		});
+
+		it("ラッパー div に rounded-xl および border クラスが適用されている", () => {
+			// Act
+			render(
+				<ScrollableTable>
+					<tbody>
+						<tr>
+							<td>cell</td>
+						</tr>
+					</tbody>
+				</ScrollableTable>,
+			);
+
+			// Assert
+			const wrapper = screen.getByRole("table").parentElement;
+			expect(wrapper).toHaveClass("rounded-xl");
+			expect(wrapper).toHaveClass("border");
+		});
+	});
+
+	describe("table 要素のスタイル", () => {
+		it("table 要素に min-w-max クラスが適用されている", () => {
+			// Act
+			render(
+				<ScrollableTable>
+					<tbody>
+						<tr>
+							<td>cell</td>
+						</tr>
+					</tbody>
+				</ScrollableTable>,
+			);
+
+			// Assert
+			expect(screen.getByRole("table")).toHaveClass("min-w-max");
+		});
+
+		it("table 要素に w-full および text-sm クラスが適用されている", () => {
+			// Act
+			render(
+				<ScrollableTable>
+					<tbody>
+						<tr>
+							<td>cell</td>
+						</tr>
+					</tbody>
+				</ScrollableTable>,
+			);
+
+			// Assert
+			const table = screen.getByRole("table");
+			expect(table).toHaveClass("w-full");
+			expect(table).toHaveClass("text-sm");
+		});
+	});
+});

--- a/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.stories.tsx
+++ b/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.stories.tsx
@@ -88,3 +88,21 @@ export const WithNegativeYear: Story = {
 		dailyBalances: sampleDailyBalances,
 	},
 };
+
+export const MobileWithData: Story = {
+	name: "データあり（モバイル）",
+	globals: {
+		viewport: { value: "mobile1", isRotated: false },
+	},
+	args: {
+		...baseArgs,
+		summary: {
+			year: 2026,
+			total_purchase_amount: 20000,
+			total_payout_amount: 21300,
+			total_net_amount: 1300,
+			total_return_rate: 106.5,
+		},
+		dailyBalances: sampleDailyBalances,
+	},
+};

--- a/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.tsx
+++ b/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.tsx
@@ -11,6 +11,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/shadcn/ui/select";
+import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { formatDateDisplay } from "@/utils/date";
 import type { BalanceDashboardProps } from "./types";
 
@@ -137,62 +138,60 @@ export default function BalanceDashboard({
 						<p>記録がありません</p>
 					</div>
 				) : (
-					<div className="overflow-hidden rounded-xl border">
-						<table className="w-full text-sm">
-							<thead>
-								<tr className="border-b bg-muted/50">
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										日付
-									</th>
-									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-										購入金額
-									</th>
-									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-										払い戻し金額
-									</th>
-									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-										プラスマイナス
-									</th>
-									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-										回収率
-									</th>
-								</tr>
-							</thead>
-							<tbody>
-								{dailyBalances.map((row) => (
-									<tr
-										key={row.date}
-										className="border-b last:border-0 hover:bg-muted/30"
+					<ScrollableTable>
+						<thead>
+							<tr className="border-b bg-muted/50">
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									日付
+								</th>
+								<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+									購入金額
+								</th>
+								<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+									払い戻し金額
+								</th>
+								<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+									プラスマイナス
+								</th>
+								<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+									回収率
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{dailyBalances.map((row) => (
+								<tr
+									key={row.date}
+									className="border-b last:border-0 hover:bg-muted/30"
+								>
+									<td className="px-4 py-3">{formatDateDisplay(row.date)}</td>
+									<td className="px-4 py-3 text-right">
+										¥{row.purchase_amount.toLocaleString()}
+									</td>
+									<td className="px-4 py-3 text-right">
+										¥{row.payout_amount.toLocaleString()}
+									</td>
+									<td
+										className={`px-4 py-3 text-right font-medium ${
+											row.net_amount >= 0 ? "text-green-600" : "text-red-600"
+										}`}
 									>
-										<td className="px-4 py-3">{formatDateDisplay(row.date)}</td>
-										<td className="px-4 py-3 text-right">
-											¥{row.purchase_amount.toLocaleString()}
-										</td>
-										<td className="px-4 py-3 text-right">
-											¥{row.payout_amount.toLocaleString()}
-										</td>
-										<td
-											className={`px-4 py-3 text-right font-medium ${
-												row.net_amount >= 0 ? "text-green-600" : "text-red-600"
-											}`}
-										>
-											{row.net_amount >= 0 ? "+" : ""}¥
-											{row.net_amount.toLocaleString()}
-										</td>
-										<td
-											className={`px-4 py-3 text-right ${
-												row.return_rate >= 100
-													? "text-green-600"
-													: "text-red-600"
-											}`}
-										>
-											{row.return_rate.toFixed(1)}%
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
+										{row.net_amount >= 0 ? "+" : ""}¥
+										{row.net_amount.toLocaleString()}
+									</td>
+									<td
+										className={`px-4 py-3 text-right ${
+											row.return_rate >= 100
+												? "text-green-600"
+												: "text-red-600"
+										}`}
+									>
+										{row.return_rate.toFixed(1)}%
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</ScrollableTable>
 				)}
 			</div>
 		</div>

--- a/source/resources/js/features/raceDetail/presentational/RaceDetail/RaceDetail.stories.tsx
+++ b/source/resources/js/features/raceDetail/presentational/RaceDetail/RaceDetail.stories.tsx
@@ -63,3 +63,13 @@ export const WeightMissing: Story = {
 		},
 	},
 };
+
+export const MobileView: Story = {
+	name: "モバイル表示",
+	globals: {
+		viewport: { value: "mobile1", isRotated: false },
+	},
+	args: {
+		race: sampleRace,
+	},
+};

--- a/source/resources/js/features/raceDetail/presentational/RaceDetail/index.tsx
+++ b/source/resources/js/features/raceDetail/presentational/RaceDetail/index.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@inertiajs/react";
 import { Button } from "@/components/shadcn/ui/button";
+import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceDetailProps } from "./types";
 
@@ -8,30 +9,28 @@ export default function RaceDetail({ race }: RaceDetailProps) {
 		<div className="flex flex-col gap-4 p-4">
 			<h1 className="text-xl font-semibold">レース詳細</h1>
 
-			<div className="overflow-x-auto rounded-xl border">
-				<table className="w-full text-sm">
-					<tbody>
-						<tr className="border-b">
-							<th className="w-32 bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
-								開催日
-							</th>
-							<td className="px-4 py-3">{formatDateDisplay(race.race_date)}</td>
-						</tr>
-						<tr className="border-b">
-							<th className="bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
-								競馬場
-							</th>
-							<td className="px-4 py-3">{race.venue_name}</td>
-						</tr>
-						<tr>
-							<th className="bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
-								レース番号
-							</th>
-							<td className="px-4 py-3">{race.race_number}R</td>
-						</tr>
-					</tbody>
-				</table>
-			</div>
+			<ScrollableTable>
+				<tbody>
+					<tr className="border-b">
+						<th className="w-32 bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
+							開催日
+						</th>
+						<td className="px-4 py-3">{formatDateDisplay(race.race_date)}</td>
+					</tr>
+					<tr className="border-b">
+						<th className="bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
+							競馬場
+						</th>
+						<td className="px-4 py-3">{race.venue_name}</td>
+					</tr>
+					<tr>
+						<th className="bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
+							レース番号
+						</th>
+						<td className="px-4 py-3">{race.race_number}R</td>
+					</tr>
+				</tbody>
+			</ScrollableTable>
 
 			<div className="flex items-center justify-between">
 				<h2 className="text-lg font-semibold">出馬表</h2>
@@ -40,42 +39,40 @@ export default function RaceDetail({ race }: RaceDetailProps) {
 				</Button>
 			</div>
 
-			<div className="overflow-x-auto rounded-xl border">
-				<table className="w-full text-sm">
-					<thead>
-						<tr className="border-b bg-muted/50">
-							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-								枠番
-							</th>
-							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-								馬番
-							</th>
-							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-								馬名
-							</th>
-							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-								騎手名
-							</th>
-							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-								馬体重
-							</th>
+			<ScrollableTable>
+				<thead>
+					<tr className="border-b bg-muted/50">
+						<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+							枠番
+						</th>
+						<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+							馬番
+						</th>
+						<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+							馬名
+						</th>
+						<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+							騎手名
+						</th>
+						<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+							馬体重
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{race.entries.map((entry) => (
+						<tr key={entry.horse_number} className="border-b last:border-0">
+							<td className="px-4 py-3">{entry.frame_number}</td>
+							<td className="px-4 py-3">{entry.horse_number}</td>
+							<td className="px-4 py-3">{entry.horse_name}</td>
+							<td className="px-4 py-3">{entry.jockey_name}</td>
+							<td className="px-4 py-3">
+								{entry.weight !== null ? `${entry.weight}kg` : "-"}
+							</td>
 						</tr>
-					</thead>
-					<tbody>
-						{race.entries.map((entry) => (
-							<tr key={entry.horse_number} className="border-b last:border-0">
-								<td className="px-4 py-3">{entry.frame_number}</td>
-								<td className="px-4 py-3">{entry.horse_number}</td>
-								<td className="px-4 py-3">{entry.horse_name}</td>
-								<td className="px-4 py-3">{entry.jockey_name}</td>
-								<td className="px-4 py-3">
-									{entry.weight !== null ? `${entry.weight}kg` : "-"}
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
+					))}
+				</tbody>
+			</ScrollableTable>
 		</div>
 	);
 }

--- a/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.stories.tsx
+++ b/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.stories.tsx
@@ -47,3 +47,13 @@ export const WithPastedText: Story = {
 			"1\t1\tコントレイル\t福永祐一\t486\n2\t2\tグランアレグリア\t川田将雅\t470\n3\t3\tフィエールマン\t池添謙一\t458\n4\t4\tクロノジェネシス\t北村友一\t462\n5\t5\tカレンブーケドール\t津村明秀\t448",
 	},
 };
+
+export const MobileView: Story = {
+	name: "モバイル表示",
+	globals: {
+		viewport: { value: "mobile1", isRotated: false },
+	},
+	args: {
+		...baseArgs,
+	},
+};

--- a/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.tsx
+++ b/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/shadcn/ui/button";
+import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceEntryRegistrationFormProps } from "./types";
 
@@ -15,30 +16,28 @@ export default function RaceEntryRegistrationForm({
 		<div className="mx-auto max-w-2xl space-y-8 p-4">
 			<h1 className="text-xl font-semibold">出走馬登録</h1>
 
-			<div className="overflow-x-auto rounded-xl border">
-				<table className="w-full text-sm">
-					<tbody>
-						<tr className="border-b">
-							<th className="w-32 bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
-								開催日
-							</th>
-							<td className="px-4 py-3">{formatDateDisplay(raceInfo.race_date)}</td>
-						</tr>
-						<tr className="border-b">
-							<th className="bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
-								競馬場
-							</th>
-							<td className="px-4 py-3">{raceInfo.venue_name}</td>
-						</tr>
-						<tr>
-							<th className="bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
-								レース番号
-							</th>
-							<td className="px-4 py-3">{raceInfo.race_number}R</td>
-						</tr>
-					</tbody>
-				</table>
-			</div>
+			<ScrollableTable>
+				<tbody>
+					<tr className="border-b">
+						<th className="w-32 bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
+							開催日
+						</th>
+						<td className="px-4 py-3">{formatDateDisplay(raceInfo.race_date)}</td>
+					</tr>
+					<tr className="border-b">
+						<th className="bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
+							競馬場
+						</th>
+						<td className="px-4 py-3">{raceInfo.venue_name}</td>
+					</tr>
+					<tr>
+						<th className="bg-muted/50 px-4 py-3 text-left font-medium text-muted-foreground">
+							レース番号
+						</th>
+						<td className="px-4 py-3">{raceInfo.race_number}R</td>
+					</tr>
+				</tbody>
+			</ScrollableTable>
 
 			<div className="space-y-2">
 				<label

--- a/source/resources/js/features/raceList/presentational/RaceList/index.stories.tsx
+++ b/source/resources/js/features/raceList/presentational/RaceList/index.stories.tsx
@@ -115,3 +115,14 @@ export const FilteredByDateAndVenue: Story = {
 		selectedVenueId: "1",
 	},
 };
+
+export const MobileWithData: Story = {
+	name: "データあり（モバイル）",
+	globals: {
+		viewport: { value: "mobile1", isRotated: false },
+	},
+	args: {
+		...baseArgs,
+		races: sampleRaces,
+	},
+};

--- a/source/resources/js/features/raceList/presentational/RaceList/index.tsx
+++ b/source/resources/js/features/raceList/presentational/RaceList/index.tsx
@@ -2,6 +2,7 @@ import { Link, router } from "@inertiajs/react";
 import { Button } from "@/components/shadcn/ui/button";
 import { Input } from "@/components/shadcn/ui/input";
 import { Label } from "@/components/shadcn/ui/label";
+import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { create, show } from "@/routes/races";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceListProps } from "./types";
@@ -64,47 +65,45 @@ export default function RaceList({
 					<Link href={create.url()}>レース情報入力</Link>
 				</div>
 			) : (
-				<div className="overflow-x-auto rounded-xl border">
-					<table className="w-full text-sm">
-						<thead>
-							<tr className="border-b bg-muted/50">
-								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-									日付
-								</th>
-								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-									開催場所
-								</th>
-								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-									レース番号
-								</th>
-								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-									レース名
-								</th>
+				<ScrollableTable>
+					<thead>
+						<tr className="border-b bg-muted/50">
+							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+								日付
+							</th>
+							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+								開催場所
+							</th>
+							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+								レース番号
+							</th>
+							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+								レース名
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{races.map((race) => (
+							<tr
+								key={race.uid}
+								className="cursor-pointer border-b last:border-0 hover:bg-muted/30"
+								onClick={() => router.visit(show.url({ race: race.uid }))}
+								onKeyDown={(e) => {
+									if (e.key === "Enter" || e.key === " ") {
+										router.visit(show.url({ race: race.uid }));
+									}
+								}}
+							>
+								<td className="px-4 py-3">
+									{formatDateDisplay(race.race_date)}
+								</td>
+								<td className="px-4 py-3">{race.venue_name}</td>
+								<td className="px-4 py-3">{race.race_number}R</td>
+								<td className="px-4 py-3">{race.race_name ?? "—"}</td>
 							</tr>
-						</thead>
-						<tbody>
-							{races.map((race) => (
-								<tr
-									key={race.uid}
-									className="cursor-pointer border-b last:border-0 hover:bg-muted/30"
-									onClick={() => router.visit(show.url({ race: race.uid }))}
-									onKeyDown={(e) => {
-										if (e.key === "Enter" || e.key === " ") {
-											router.visit(show.url({ race: race.uid }));
-										}
-									}}
-								>
-									<td className="px-4 py-3">
-										{formatDateDisplay(race.race_date)}
-									</td>
-									<td className="px-4 py-3">{race.venue_name}</td>
-									<td className="px-4 py-3">{race.race_number}R</td>
-									<td className="px-4 py-3">{race.race_name ?? "—"}</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
-				</div>
+						))}
+					</tbody>
+				</ScrollableTable>
 			)}
 		</div>
 	);

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
@@ -215,3 +215,17 @@ export const NoFinishingHorses: Story = {
 		},
 	},
 };
+
+export const MobileWithData: Story = {
+	name: "データあり（モバイル）",
+	globals: {
+		viewport: { value: "mobile1", isRotated: false },
+	},
+	args: {
+		race: {
+			...baseRace,
+			payouts: allPayouts,
+			finishing_horses: sampleFinishingHorses,
+		},
+	},
+};

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -1,3 +1,4 @@
+import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceResultDetailProps } from "./types";
 import { formatHorseNumbers } from "./utils";
@@ -20,101 +21,97 @@ export default function RaceResultDetail({ race }: RaceResultDetailProps) {
 						着順データがありません
 					</p>
 				) : (
-					<div className="overflow-x-auto rounded-xl border">
-						<table className="w-full text-sm">
-							<thead>
-								<tr className="border-b bg-muted/50">
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										着順
-									</th>
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										枠番
-									</th>
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										馬番
-									</th>
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										馬名
-									</th>
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										騎手
-									</th>
-									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-										タイム
-									</th>
+					<ScrollableTable>
+						<thead>
+							<tr className="border-b bg-muted/50">
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									着順
+								</th>
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									枠番
+								</th>
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									馬番
+								</th>
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									馬名
+								</th>
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									騎手
+								</th>
+								<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+									タイム
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{race.finishing_horses.map((horse) => (
+								<tr
+									key={horse.horse_number}
+									className="border-b last:border-0 hover:bg-muted/30"
+								>
+									<td className="px-4 py-3">
+										{horse.finishing_order}
+									</td>
+									<td className="px-4 py-3">
+										{horse.frame_number}
+									</td>
+									<td className="px-4 py-3">
+										{horse.horse_number}
+									</td>
+									<td className="px-4 py-3">
+										{horse.horse_name}
+									</td>
+									<td className="px-4 py-3">
+										{horse.jockey_name}
+									</td>
+									<td className="px-4 py-3 text-right">
+										{horse.race_time}
+									</td>
 								</tr>
-							</thead>
-							<tbody>
-								{race.finishing_horses.map((horse) => (
-									<tr
-										key={horse.horse_number}
-										className="border-b last:border-0 hover:bg-muted/30"
-									>
-										<td className="px-4 py-3">
-											{horse.finishing_order}
-										</td>
-										<td className="px-4 py-3">
-											{horse.frame_number}
-										</td>
-										<td className="px-4 py-3">
-											{horse.horse_number}
-										</td>
-										<td className="px-4 py-3">
-											{horse.horse_name}
-										</td>
-										<td className="px-4 py-3">
-											{horse.jockey_name}
-										</td>
-										<td className="px-4 py-3 text-right">
-											{horse.race_time}
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
+							))}
+						</tbody>
+					</ScrollableTable>
 				)}
 			</div>
 
-			<div className="overflow-x-auto rounded-xl border">
-				<table className="w-full text-sm">
-					<thead>
-						<tr className="border-b bg-muted/50">
-							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-								券種
-							</th>
-							<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-								馬番
-							</th>
-							<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-								払戻金額
-							</th>
-							<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-								人気
-							</th>
+			<ScrollableTable>
+				<thead>
+					<tr className="border-b bg-muted/50">
+						<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+							券種
+						</th>
+						<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+							馬番
+						</th>
+						<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+							払戻金額
+						</th>
+						<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+							人気
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{race.payouts.map((payout) => (
+						<tr
+							key={`${payout.ticket_type_name}-${payout.horses.map((h) => h.horse_number).join("-")}`}
+							className="border-b last:border-0 hover:bg-muted/30"
+						>
+							<td className="px-4 py-3">{payout.ticket_type_label}</td>
+							<td className="px-4 py-3">
+								{formatHorseNumbers(payout.horses, payout.ticket_type_name)}
+							</td>
+							<td className="px-4 py-3 text-right">
+								¥{payout.payout_amount.toLocaleString()}
+							</td>
+							<td className="px-4 py-3 text-right">
+								{payout.popularity}人気
+							</td>
 						</tr>
-					</thead>
-					<tbody>
-						{race.payouts.map((payout) => (
-							<tr
-								key={`${payout.ticket_type_name}-${payout.horses.map((h) => h.horse_number).join("-")}`}
-								className="border-b last:border-0 hover:bg-muted/30"
-							>
-								<td className="px-4 py-3">{payout.ticket_type_label}</td>
-								<td className="px-4 py-3">
-									{formatHorseNumbers(payout.horses, payout.ticket_type_name)}
-								</td>
-								<td className="px-4 py-3 text-right">
-									¥{payout.payout_amount.toLocaleString()}
-								</td>
-								<td className="px-4 py-3 text-right">
-									{payout.popularity}人気
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
+					))}
+				</tbody>
+			</ScrollableTable>
 		</div>
 	);
 }

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseList/index.stories.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseList/index.stories.tsx
@@ -157,3 +157,14 @@ export const WithNoPayoutAmount: Story = {
 		purchases: samplePurchases,
 	},
 };
+
+export const MobileWithData: Story = {
+	name: "データあり（モバイル）",
+	globals: {
+		viewport: { value: "mobile1", isRotated: false },
+	},
+	args: {
+		...baseArgs,
+		purchases: samplePurchases,
+	},
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseList/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseList/index.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@inertiajs/react";
 import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
+import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { newMethod } from "@/routes/tickets";
 import { formatDateDisplay } from "@/utils/date";
 import type { TicketPurchaseListProps } from "./types";
@@ -28,89 +29,87 @@ export default function TicketPurchaseList({
 				</div>
 			) : (
 				<>
-					<div className="overflow-hidden rounded-xl border">
-						<table className="w-full text-sm">
-							<thead>
-								<tr className="border-b bg-muted/50">
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										日付
-									</th>
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										レース場
-									</th>
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										レース番号
-									</th>
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										券種
-									</th>
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										買い方
-									</th>
-									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-										購入金額
-									</th>
-									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-										払い戻し金額
-									</th>
-									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-										レース結果
-									</th>
-								</tr>
-							</thead>
-							<tbody>
-								{purchases.map((purchase) => (
-									<tr
-										key={purchase.id}
-										className="border-b last:border-0 hover:bg-muted/30"
-									>
-										<td className="px-4 py-3">
-											{purchase.race_date
-												? formatDateDisplay(purchase.race_date)
-												: "-"}
-										</td>
-										<td className="px-4 py-3">{purchase.venue_name ?? "-"}</td>
-										<td className="px-4 py-3">{purchase.race_number ?? "-"}</td>
-										<td className="px-4 py-3">{purchase.ticket_type_label}</td>
-										<td className="px-4 py-3">
-											{formatSelections(purchase.selections)}
-										</td>
-										<td className="px-4 py-3 text-right">
-											{purchase.amount != null
-												? `¥${purchase.amount.toLocaleString()}`
-												: "-"}
-										</td>
-										<td className="px-4 py-3 text-right">
-											{purchase.payout_amount != null
-												? `¥${purchase.payout_amount.toLocaleString()}`
-												: "-"}
-										</td>
-										<td className="px-4 py-3">
-											{purchase.race_uid != null ? (
-												purchase.has_race_result ? (
-													<Link
-														href={`/races/${purchase.race_uid}/result/edit`}
-														className="text-sm underline"
-													>
-														確認・編集
-													</Link>
-												) : (
-													<Link
-														href={`/races/${purchase.race_uid}/result/new`}
-														className="text-sm underline"
-													>
-														結果入力
-													</Link>
-												)
+					<ScrollableTable>
+						<thead>
+							<tr className="border-b bg-muted/50">
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									日付
+								</th>
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									レース場
+								</th>
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									レース番号
+								</th>
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									券種
+								</th>
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									買い方
+								</th>
+								<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+									購入金額
+								</th>
+								<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+									払い戻し金額
+								</th>
+								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+									レース結果
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{purchases.map((purchase) => (
+								<tr
+									key={purchase.id}
+									className="border-b last:border-0 hover:bg-muted/30"
+								>
+									<td className="px-4 py-3">
+										{purchase.race_date
+											? formatDateDisplay(purchase.race_date)
+											: "-"}
+									</td>
+									<td className="px-4 py-3">{purchase.venue_name ?? "-"}</td>
+									<td className="px-4 py-3">{purchase.race_number ?? "-"}</td>
+									<td className="px-4 py-3">{purchase.ticket_type_label}</td>
+									<td className="px-4 py-3">
+										{formatSelections(purchase.selections)}
+									</td>
+									<td className="px-4 py-3 text-right">
+										{purchase.amount != null
+											? `¥${purchase.amount.toLocaleString()}`
+											: "-"}
+									</td>
+									<td className="px-4 py-3 text-right">
+										{purchase.payout_amount != null
+											? `¥${purchase.payout_amount.toLocaleString()}`
+											: "-"}
+									</td>
+									<td className="px-4 py-3">
+										{purchase.race_uid != null ? (
+											purchase.has_race_result ? (
+												<Link
+													href={`/races/${purchase.race_uid}/result/edit`}
+													className="text-sm underline"
+												>
+													確認・編集
+												</Link>
 											) : (
-												"-"
-											)}
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
+												<Link
+													href={`/races/${purchase.race_uid}/result/new`}
+													className="text-sm underline"
+												>
+													結果入力
+												</Link>
+											)
+										) : (
+											"-"
+										)}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</ScrollableTable>
 
 					{hasMore && (
 						<div className="flex justify-center">


### PR DESCRIPTION
## やったこと

- テーブルに横スクロール機能を持たせる `ScrollableTable` 共通コンポーネントを新規作成した
- 既存の各テーブルコンポーネント（`BalanceDashboard`、`RaceDetail`、`RaceEntryRegistrationForm`、`RaceList`、`RaceResultDetail`、`TicketPurchaseList`）を `ScrollableTable` を使うよう修正した
- `ScrollableTable` のユニットテスト・Storybook ストーリー（モバイル表示含む）を追加した
- `RaceEntryRegistrationForm` にモバイル表示ストーリーを追加した

## 結果

<\!-- スクリーンショット・動画を添付する -->

## 動作確認済み

- [ ] 各テーブルコンポーネントでモバイル表示時に横スクロールできることを確認