### PR TITLE
[patch] フロントエンドの関数定義をアロー関数に統一

### DIFF
--- a/docs/architecture/frontend/naming-conventions.md
+++ b/docs/architecture/frontend/naming-conventions.md
@@ -30,6 +30,8 @@
 | イベントハンドラ | `handle` + PascalCase | `handleSubmit`, `handleRaceSelect` |
 | 関数定義 | アロー関数を使用 | `const foo = () => {}` |
 
+`export default` する場合は const に代入してから default export する。自動生成・サードパーティ由来のコードは対象外で、`biome.json` の `files.ignore` で除外している。
+
 ## 型・インターフェース
 
 | 対象 | 規則 | 例 |

--- a/docs/architecture/frontend/naming-conventions.md
+++ b/docs/architecture/frontend/naming-conventions.md
@@ -28,6 +28,7 @@
 | 定数（モジュールスコープ） | UPPER_SNAKE_CASE | `MAX_RACE_COUNT` |
 | カスタムフック | `use` + PascalCase | `useRaceList`, `useBalanceInput` |
 | イベントハンドラ | `handle` + PascalCase | `handleSubmit`, `handleRaceSelect` |
+| 関数定義 | アロー関数を使用 | `const foo = () => {}` |
 
 ## 型・インターフェース
 

--- a/source/biome.json
+++ b/source/biome.json
@@ -6,7 +6,10 @@
     "linter": {
         "enabled": true,
         "rules": {
-            "recommended": true
+            "recommended": true,
+            "complexity": {
+                "useArrowFunction": "error"
+            }
         }
     },
     "formatter": {

--- a/source/resources/js/components/presentational/AlertError/index.tsx
+++ b/source/resources/js/components/presentational/AlertError/index.tsx
@@ -5,13 +5,13 @@ import {
 	AlertTitle,
 } from "@/components/shadcn/ui/alert";
 
-export default function AlertError({
+const AlertError = ({
 	errors,
 	title,
 }: {
 	errors: string[];
 	title?: string;
-}) {
+}) => {
 	return (
 		<Alert variant="destructive">
 			<AlertCircleIcon />
@@ -25,4 +25,6 @@ export default function AlertError({
 			</AlertDescription>
 		</Alert>
 	);
-}
+};
+
+export default AlertError;

--- a/source/resources/js/components/presentational/AppContent/index.tsx
+++ b/source/resources/js/components/presentational/AppContent/index.tsx
@@ -6,7 +6,11 @@ type Props = React.ComponentProps<"main"> & {
 	variant?: AppVariant;
 };
 
-export function AppContent({ variant = "sidebar", children, ...props }: Props) {
+export const AppContent = ({
+	variant = "sidebar",
+	children,
+	...props
+}: Props) => {
 	if (variant === "sidebar") {
 		return <SidebarInset {...props}>{children}</SidebarInset>;
 	}
@@ -19,4 +23,4 @@ export function AppContent({ variant = "sidebar", children, ...props }: Props) {
 			{children}
 		</main>
 	);
-}
+};

--- a/source/resources/js/components/presentational/AppHeader/index.tsx
+++ b/source/resources/js/components/presentational/AppHeader/index.tsx
@@ -67,7 +67,7 @@ const rightNavItems: NavItem[] = [
 const activeItemStyles =
 	"text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100";
 
-export function AppHeader({ breadcrumbs = [] }: Props) {
+export const AppHeader = ({ breadcrumbs = [] }: Props) => {
 	const page = usePage();
 	const { auth } = page.props;
 	const getInitials = useInitials();
@@ -231,4 +231,4 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
 			)}
 		</>
 	);
-}
+};

--- a/source/resources/js/components/presentational/AppLogo/index.tsx
+++ b/source/resources/js/components/presentational/AppLogo/index.tsx
@@ -1,6 +1,6 @@
 import AppLogoIcon from "@/components/presentational/AppLogoIcon";
 
-export default function AppLogo() {
+const AppLogo = () => {
 	return (
 		<>
 			<div className="flex aspect-square size-8 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground">
@@ -13,4 +13,6 @@ export default function AppLogo() {
 			</div>
 		</>
 	);
-}
+};
+
+export default AppLogo;

--- a/source/resources/js/components/presentational/AppLogoIcon/index.tsx
+++ b/source/resources/js/components/presentational/AppLogoIcon/index.tsx
@@ -1,6 +1,6 @@
 import type { SVGAttributes } from "react";
 
-export default function AppLogoIcon(props: SVGAttributes<SVGElement>) {
+const AppLogoIcon = (props: SVGAttributes<SVGElement>) => {
 	return (
 		<svg
 			{...props}
@@ -15,4 +15,6 @@ export default function AppLogoIcon(props: SVGAttributes<SVGElement>) {
 			/>
 		</svg>
 	);
-}
+};
+
+export default AppLogoIcon;

--- a/source/resources/js/components/presentational/AppShell/index.tsx
+++ b/source/resources/js/components/presentational/AppShell/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 	variant?: AppVariant;
 };
 
-export function AppShell({ children, variant = "sidebar" }: Props) {
+export const AppShell = ({ children, variant = "sidebar" }: Props) => {
 	const isOpen = usePage().props.sidebarOpen;
 
 	if (variant === "header") {
@@ -16,4 +16,4 @@ export function AppShell({ children, variant = "sidebar" }: Props) {
 	}
 
 	return <SidebarProvider defaultOpen={isOpen}>{children}</SidebarProvider>;
-}
+};

--- a/source/resources/js/components/presentational/AppSidebar/index.tsx
+++ b/source/resources/js/components/presentational/AppSidebar/index.tsx
@@ -49,7 +49,7 @@ const footerNavItems: NavItem[] = [
 	},
 ];
 
-export function AppSidebar() {
+export const AppSidebar = () => {
 	return (
 		<Sidebar collapsible="icon" variant="inset">
 			<SidebarHeader>
@@ -74,4 +74,4 @@ export function AppSidebar() {
 			</SidebarFooter>
 		</Sidebar>
 	);
-}
+};

--- a/source/resources/js/components/presentational/AppSidebarHeader/index.tsx
+++ b/source/resources/js/components/presentational/AppSidebarHeader/index.tsx
@@ -2,11 +2,11 @@ import { Breadcrumbs } from "@/components/presentational/Breadcrumbs";
 import { SidebarTrigger } from "@/components/shadcn/ui/sidebar";
 import type { BreadcrumbItem as BreadcrumbItemType } from "@/types";
 
-export function AppSidebarHeader({
+export const AppSidebarHeader = ({
 	breadcrumbs = [],
 }: {
 	breadcrumbs?: BreadcrumbItemType[];
-}) {
+}) => {
 	return (
 		<header className="flex h-16 shrink-0 items-center gap-2 border-b border-sidebar-border/50 px-6 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4">
 			<div className="flex items-center gap-2">
@@ -15,4 +15,4 @@ export function AppSidebarHeader({
 			</div>
 		</header>
 	);
-}
+};

--- a/source/resources/js/components/presentational/Breadcrumbs/index.tsx
+++ b/source/resources/js/components/presentational/Breadcrumbs/index.tsx
@@ -10,11 +10,11 @@ import {
 } from "@/components/shadcn/ui/breadcrumb";
 import type { BreadcrumbItem as BreadcrumbItemType } from "@/types";
 
-export function Breadcrumbs({
+export const Breadcrumbs = ({
 	breadcrumbs,
 }: {
 	breadcrumbs: BreadcrumbItemType[];
-}) {
+}) => {
 	return (
 		<>
 			{breadcrumbs.length > 0 && (
@@ -43,4 +43,4 @@ export function Breadcrumbs({
 			)}
 		</>
 	);
-}
+};

--- a/source/resources/js/components/presentational/Heading/index.tsx
+++ b/source/resources/js/components/presentational/Heading/index.tsx
@@ -1,4 +1,4 @@
-export default function Heading({
+const Heading = ({
 	title,
 	description,
 	variant = "default",
@@ -6,7 +6,7 @@ export default function Heading({
 	title: string;
 	description?: string;
 	variant?: "default" | "small";
-}) {
+}) => {
 	return (
 		<header className={variant === "small" ? "" : "mb-8 space-y-0.5"}>
 			<h2
@@ -23,4 +23,6 @@ export default function Heading({
 			)}
 		</header>
 	);
-}
+};
+
+export default Heading;

--- a/source/resources/js/components/presentational/InputError/index.tsx
+++ b/source/resources/js/components/presentational/InputError/index.tsx
@@ -1,11 +1,11 @@
 import type { HTMLAttributes } from "react";
 import { cn } from "@/lib/utils";
 
-export default function InputError({
+const InputError = ({
 	message,
 	className = "",
 	...props
-}: HTMLAttributes<HTMLParagraphElement> & { message?: string }) {
+}: HTMLAttributes<HTMLParagraphElement> & { message?: string }) => {
 	return message ? (
 		<p
 			{...props}
@@ -14,4 +14,6 @@ export default function InputError({
 			{message}
 		</p>
 	) : null;
-}
+};
+
+export default InputError;

--- a/source/resources/js/components/presentational/NavFooter/index.tsx
+++ b/source/resources/js/components/presentational/NavFooter/index.tsx
@@ -9,13 +9,13 @@ import {
 import { toUrl } from "@/lib/utils";
 import type { NavItem } from "@/types";
 
-export function NavFooter({
+export const NavFooter = ({
 	items,
 	className,
 	...props
 }: ComponentPropsWithoutRef<typeof SidebarGroup> & {
 	items: NavItem[];
-}) {
+}) => {
 	return (
 		<SidebarGroup
 			{...props}
@@ -44,4 +44,4 @@ export function NavFooter({
 			</SidebarGroupContent>
 		</SidebarGroup>
 	);
-}
+};

--- a/source/resources/js/components/presentational/NavMain/index.tsx
+++ b/source/resources/js/components/presentational/NavMain/index.tsx
@@ -9,7 +9,7 @@ import {
 import { useCurrentUrl } from "@/hooks/use-current-url";
 import type { NavItem } from "@/types";
 
-export function NavMain({ items = [] }: { items: NavItem[] }) {
+export const NavMain = ({ items = [] }: { items: NavItem[] }) => {
 	const { isCurrentUrl } = useCurrentUrl();
 
 	return (
@@ -33,4 +33,4 @@ export function NavMain({ items = [] }: { items: NavItem[] }) {
 			</SidebarMenu>
 		</SidebarGroup>
 	);
-}
+};

--- a/source/resources/js/components/presentational/NavUser/index.tsx
+++ b/source/resources/js/components/presentational/NavUser/index.tsx
@@ -15,7 +15,7 @@ import { UserInfo } from "@/components/presentational/UserInfo";
 import { UserMenuContent } from "@/components/presentational/UserMenuContent";
 import { useIsMobile } from "@/hooks/use-mobile";
 
-export function NavUser() {
+export const NavUser = () => {
 	const { auth } = usePage().props;
 	const { state } = useSidebar();
 	const isMobile = useIsMobile();
@@ -51,4 +51,4 @@ export function NavUser() {
 			</SidebarMenuItem>
 		</SidebarMenu>
 	);
-}
+};

--- a/source/resources/js/components/presentational/PasswordInput/index.tsx
+++ b/source/resources/js/components/presentational/PasswordInput/index.tsx
@@ -4,11 +4,11 @@ import { useState } from "react";
 import { Input } from "@/components/shadcn/ui/input";
 import { cn } from "@/lib/utils";
 
-export default function PasswordInput({
+const PasswordInput = ({
 	className,
 	ref,
 	...props
-}: Omit<ComponentProps<"input">, "type"> & { ref?: Ref<HTMLInputElement> }) {
+}: Omit<ComponentProps<"input">, "type"> & { ref?: Ref<HTMLInputElement> }) => {
 	const [showPassword, setShowPassword] = useState(false);
 
 	return (
@@ -34,4 +34,6 @@ export default function PasswordInput({
 			</button>
 		</div>
 	);
-}
+};
+
+export default PasswordInput;

--- a/source/resources/js/components/presentational/ScrollableTable/index.tsx
+++ b/source/resources/js/components/presentational/ScrollableTable/index.tsx
@@ -4,10 +4,12 @@ type Props = {
 	children: ReactNode;
 };
 
-export default function ScrollableTable({ children }: Props) {
+const ScrollableTable = ({ children }: Props) => {
 	return (
 		<div className="overflow-x-auto rounded-xl border">
 			<table className="w-full min-w-max text-sm">{children}</table>
 		</div>
 	);
-}
+};
+
+export default ScrollableTable;

--- a/source/resources/js/components/presentational/TextLink/index.tsx
+++ b/source/resources/js/components/presentational/TextLink/index.tsx
@@ -4,11 +4,7 @@ import { cn } from "@/lib/utils";
 
 type Props = ComponentProps<typeof Link>;
 
-export default function TextLink({
-	className = "",
-	children,
-	...props
-}: Props) {
+const TextLink = ({ className = "", children, ...props }: Props) => {
 	return (
 		<Link
 			className={cn(
@@ -20,4 +16,6 @@ export default function TextLink({
 			{children}
 		</Link>
 	);
-}
+};
+
+export default TextLink;

--- a/source/resources/js/components/presentational/UserInfo/index.tsx
+++ b/source/resources/js/components/presentational/UserInfo/index.tsx
@@ -6,13 +6,13 @@ import {
 import { useInitials } from "@/hooks/use-initials";
 import type { User } from "@/types";
 
-export function UserInfo({
+export const UserInfo = ({
 	user,
 	showEmail = false,
 }: {
 	user: User;
 	showEmail?: boolean;
-}) {
+}) => {
 	const getInitials = useInitials();
 
 	return (
@@ -33,4 +33,4 @@ export function UserInfo({
 			</div>
 		</>
 	);
-}
+};

--- a/source/resources/js/components/presentational/UserMenuContent/index.tsx
+++ b/source/resources/js/components/presentational/UserMenuContent/index.tsx
@@ -16,7 +16,7 @@ type Props = {
 	user: User;
 };
 
-export function UserMenuContent({ user }: Props) {
+export const UserMenuContent = ({ user }: Props) => {
 	const cleanup = useMobileNavigation();
 
 	const handleLogout = () => {
@@ -60,4 +60,4 @@ export function UserMenuContent({ user }: Props) {
 			</DropdownMenuItem>
 		</>
 	);
-}
+};

--- a/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.tsx
+++ b/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.tsx
@@ -15,13 +15,13 @@ import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { formatDateDisplay } from "@/utils/date";
 import type { BalanceDashboardProps } from "./types";
 
-export default function BalanceDashboard({
+const BalanceDashboard = ({
 	selectedYear,
 	availableYears,
 	summary,
 	dailyBalances,
 	onYearChange,
-}: BalanceDashboardProps) {
+}: BalanceDashboardProps) => {
 	return (
 		<div className="flex flex-col gap-6 p-4">
 			<div className="flex items-center justify-between">
@@ -196,7 +196,9 @@ export default function BalanceDashboard({
 			</div>
 		</div>
 	);
-}
+};
+
+export default BalanceDashboard;
 
 export type {
 	BalanceDashboardProps,

--- a/source/resources/js/features/horseDetail/presentational/HorseDetail/index.tsx
+++ b/source/resources/js/features/horseDetail/presentational/HorseDetail/index.tsx
@@ -2,7 +2,7 @@ import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { formatDateDisplay } from "@/utils/date";
 import type { HorseDetailProps } from "./types";
 
-export default function HorseDetail({ horse }: HorseDetailProps) {
+const HorseDetail = ({ horse }: HorseDetailProps) => {
 	return (
 		<div className="flex flex-col gap-4 p-4">
 			<h1 className="text-xl font-semibold">競走馬詳細</h1>
@@ -105,6 +105,8 @@ export default function HorseDetail({ horse }: HorseDetailProps) {
 			)}
 		</div>
 	);
-}
+};
+
+export default HorseDetail;
 
 export type { HorseDetailItem, HorseDetailProps } from "./types";

--- a/source/resources/js/features/raceDetail/containers/RaceDetailContainer/index.tsx
+++ b/source/resources/js/features/raceDetail/containers/RaceDetailContainer/index.tsx
@@ -27,7 +27,7 @@ type Props = {
  * API 失敗時は state を元に戻して toast でエラーを通知する。
  * ラベル編集はキー入力中の連打を避けるため列ごとに 500ms デバウンスする。
  */
-export default function RaceDetailContainer({ race }: Props) {
+const RaceDetailContainer = ({ race }: Props) => {
 	const [markColumns, setMarkColumns] = useState<RaceMarkColumn[]>(
 		race.mark_columns,
 	);
@@ -137,4 +137,6 @@ export default function RaceDetailContainer({ race }: Props) {
 			onChangeColumnLabel={handleChangeColumnLabel}
 		/>
 	);
-}
+};
+
+export default RaceDetailContainer;

--- a/source/resources/js/features/raceDetail/presentational/RaceDetail/RaceMarkColumnHeader/index.tsx
+++ b/source/resources/js/features/raceDetail/presentational/RaceDetail/RaceMarkColumnHeader/index.tsx
@@ -9,11 +9,11 @@ type Props = {
 	onRemove: () => void;
 };
 
-export default function RaceMarkColumnHeader({
+const RaceMarkColumnHeader = ({
 	column,
 	onChangeLabel,
 	onRemove,
-}: Props) {
+}: Props) => {
 	if (column.type === "own") {
 		return <span className="font-medium text-muted-foreground">自分</span>;
 	}
@@ -39,4 +39,6 @@ export default function RaceMarkColumnHeader({
 			</Button>
 		</div>
 	);
-}
+};
+
+export default RaceMarkColumnHeader;

--- a/source/resources/js/features/raceDetail/presentational/RaceDetail/RaceMarkSelect/index.tsx
+++ b/source/resources/js/features/raceDetail/presentational/RaceDetail/RaceMarkSelect/index.tsx
@@ -15,7 +15,7 @@ type Props = {
 	ariaLabel?: string;
 };
 
-export default function RaceMarkSelect({ value, onChange, ariaLabel }: Props) {
+const RaceMarkSelect = ({ value, onChange, ariaLabel }: Props) => {
 	return (
 		<Select
 			value={value ?? UNSELECTED_VALUE}
@@ -40,4 +40,6 @@ export default function RaceMarkSelect({ value, onChange, ariaLabel }: Props) {
 			</SelectContent>
 		</Select>
 	);
-}
+};
+
+export default RaceMarkSelect;

--- a/source/resources/js/features/raceDetail/presentational/RaceDetail/index.tsx
+++ b/source/resources/js/features/raceDetail/presentational/RaceDetail/index.tsx
@@ -12,28 +12,28 @@ import type {
 	RaceMarkValue,
 } from "./types";
 
-function findMarkValue(
+const findMarkValue = (
 	marks: RaceMarkValue[],
 	columnId: number,
 	raceEntryId: number,
-): MarkValue | null {
+): MarkValue | null => {
 	const found = marks.find(
 		(m) => m.column_id === columnId && m.race_entry_id === raceEntryId,
 	);
 	return found ? found.mark_value : null;
-}
+};
 
-function sortColumns(columns: RaceMarkColumn[]): RaceMarkColumn[] {
+const sortColumns = (columns: RaceMarkColumn[]): RaceMarkColumn[] => {
 	return [...columns].sort((a, b) => a.display_order - b.display_order);
-}
+};
 
-export default function RaceDetail({
+const RaceDetail = ({
 	race,
 	onMarkChange,
 	onAddOtherColumn,
 	onRemoveOtherColumn,
 	onChangeColumnLabel,
-}: RaceDetailProps) {
+}: RaceDetailProps) => {
 	const sortedColumns = sortColumns(race.mark_columns);
 
 	return (
@@ -155,7 +155,9 @@ export default function RaceDetail({
 			</ScrollableTable>
 		</div>
 	);
-}
+};
+
+export default RaceDetail;
 
 export type {
 	RaceDetailItem,

--- a/source/resources/js/features/raceDetail/requests/csrf.ts
+++ b/source/resources/js/features/raceDetail/requests/csrf.ts
@@ -2,7 +2,7 @@
  * <meta name="csrf-token"> から CSRF トークンを取り出す。
  * テスト等で meta タグが存在しない場合は空文字列を返す。
  */
-export function getCsrfToken(): string {
+export const getCsrfToken = (): string => {
 	if (typeof document === "undefined") {
 		return "";
 	}
@@ -10,16 +10,16 @@ export function getCsrfToken(): string {
 		'meta[name="csrf-token"]',
 	);
 	return meta?.content ?? "";
-}
+};
 
 /**
  * 認証付き JSON リクエストの共通ヘッダ。
  */
-export function buildJsonHeaders(): HeadersInit {
+export const buildJsonHeaders = (): HeadersInit => {
 	return {
 		"Content-Type": "application/json",
 		Accept: "application/json",
 		"X-Requested-With": "XMLHttpRequest",
 		"X-CSRF-TOKEN": getCsrfToken(),
 	};
-}
+};

--- a/source/resources/js/features/raceEntry/containers/RaceEntryRegistrationFormContainer/index.tsx
+++ b/source/resources/js/features/raceEntry/containers/RaceEntryRegistrationFormContainer/index.tsx
@@ -13,10 +13,10 @@ type RaceEntryFormData = {
 	paste_text: string;
 };
 
-export default function RaceEntryRegistrationFormContainer({
+const RaceEntryRegistrationFormContainer = ({
 	raceUid,
 	raceInfo,
-}: RaceEntryRegistrationFormContainerProps) {
+}: RaceEntryRegistrationFormContainerProps) => {
 	const [pastedText, setPastedText] = useState("");
 
 	const { isSubmitting, handleSubmit: submit } = useFormSubmit<RaceEntryFormData>({
@@ -45,4 +45,6 @@ export default function RaceEntryRegistrationFormContainer({
 			onSubmit={handleSubmit}
 		/>
 	);
-}
+};
+
+export default RaceEntryRegistrationFormContainer;

--- a/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.tsx
+++ b/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.tsx
@@ -5,13 +5,13 @@ import type { RaceEntryRegistrationFormProps } from "./types";
 
 export type { RaceEntryRegistrationFormProps } from "./types";
 
-export default function RaceEntryRegistrationForm({
+const RaceEntryRegistrationForm = ({
 	raceInfo,
 	pastedText,
 	isSubmitting,
 	onPastedTextChange,
 	onSubmit,
-}: RaceEntryRegistrationFormProps) {
+}: RaceEntryRegistrationFormProps) => {
 	return (
 		<div className="mx-auto max-w-2xl space-y-8 p-4">
 			<h1 className="text-xl font-semibold">出走馬登録</h1>
@@ -71,4 +71,6 @@ export default function RaceEntryRegistrationForm({
 			</div>
 		</div>
 	);
-}
+};
+
+export default RaceEntryRegistrationForm;

--- a/source/resources/js/features/raceInput/containers/RaceInputFormContainer/index.tsx
+++ b/source/resources/js/features/raceInput/containers/RaceInputFormContainer/index.tsx
@@ -19,13 +19,13 @@ type RaceInputFormData = {
 	paste_text: string;
 };
 
-export default function RaceInputFormContainer({
+const RaceInputFormContainer = ({
 	venues,
 	initialVenueId,
 	initialRaceDate,
 	initialRaceNumber,
 	initialRaceName,
-}: RaceInputFormContainerProps) {
+}: RaceInputFormContainerProps) => {
 	// フォームから受け取る送信成功時のリセット関数を保持する。
 	// useFormSubmit の onSuccess は最新のクロージャを参照する必要があるため ref で受け渡す。
 	const formOnSuccessRef = useRef<(() => void) | undefined>(undefined);
@@ -58,4 +58,6 @@ export default function RaceInputFormContainer({
 			onSubmit={handleSubmit}
 		/>
 	);
-}
+};
+
+export default RaceInputFormContainer;

--- a/source/resources/js/features/raceInput/presentational/RaceInputForm/index.tsx
+++ b/source/resources/js/features/raceInput/presentational/RaceInputForm/index.tsx
@@ -30,14 +30,14 @@ type Props = {
 
 const RACE_NUMBERS = Array.from({ length: 12 }, (_, i) => i + 1);
 
-export default function RaceInputForm({
+const RaceInputForm = ({
 	venues,
 	initialVenueId,
 	initialRaceDate,
 	initialRaceNumber,
 	initialRaceName,
 	onSubmit,
-}: Props) {
+}: Props) => {
 	const [venueId, setVenueId] = useState<string>(
 		initialVenueId ? String(initialVenueId) : "",
 	);
@@ -147,6 +147,8 @@ export default function RaceInputForm({
 			</Button>
 		</div>
 	);
-}
+};
+
+export default RaceInputForm;
 
 export type { Props as RaceInputFormProps };

--- a/source/resources/js/features/raceList/presentational/RaceList/index.tsx
+++ b/source/resources/js/features/raceList/presentational/RaceList/index.tsx
@@ -7,14 +7,14 @@ import { create, show } from "@/routes/races";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceListProps } from "./types";
 
-export default function RaceList({
+const RaceList = ({
 	races,
 	venues,
 	selectedDate,
 	selectedVenueId,
 	onDateChange,
 	onVenueChange,
-}: RaceListProps) {
+}: RaceListProps) => {
 	return (
 		<div className="flex flex-col gap-4 p-4">
 			<div className="flex items-center justify-between">
@@ -107,6 +107,8 @@ export default function RaceList({
 			)}
 		</div>
 	);
-}
+};
+
+export default RaceList;
 
 export type { RaceListItem, RaceListProps } from "./types";

--- a/source/resources/js/features/raceList/utils/getDefaultRaceDate.ts
+++ b/source/resources/js/features/raceList/utils/getDefaultRaceDate.ts
@@ -1,8 +1,15 @@
+const formatDate = (date: Date): string => {
+	const y = date.getFullYear();
+	const m = String(date.getMonth() + 1).padStart(2, "0");
+	const d = String(date.getDate()).padStart(2, "0");
+	return `${y}-${m}-${d}`;
+};
+
 /**
  * 直近の土曜日または日曜日を返す。
  * 今日が土日ならば今日、それ以外は直前の日曜日を返す。
  */
-export function getDefaultRaceDate(): string {
+export const getDefaultRaceDate = (): string => {
 	const today = new Date();
 	const day = today.getDay(); // 0=Sun, 6=Sat
 
@@ -13,11 +20,4 @@ export function getDefaultRaceDate(): string {
 	const sunday = new Date(today);
 	sunday.setDate(today.getDate() - day);
 	return formatDate(sunday);
-}
-
-function formatDate(date: Date): string {
-	const y = date.getFullYear();
-	const m = String(date.getMonth() + 1).padStart(2, "0");
-	const d = String(date.getDate()).padStart(2, "0");
-	return `${y}-${m}-${d}`;
-}
+};

--- a/source/resources/js/features/raceResult/containers/RaceResultFormContainer/index.tsx
+++ b/source/resources/js/features/raceResult/containers/RaceResultFormContainer/index.tsx
@@ -15,13 +15,13 @@ type RaceResultFormData = {
 	text: string;
 };
 
-export default function RaceResultFormContainer({
+const RaceResultFormContainer = ({
 	raceUid,
 	venueName,
 	raceDate,
 	raceNumber,
 	disabled,
-}: RaceResultFormContainerProps) {
+}: RaceResultFormContainerProps) => {
 	const [resultPasteValue, setResultPasteValue] = useState("");
 	const [payoutPasteValue, setPayoutPasteValue] = useState("");
 	const [resultParseError, setResultParseError] = useState<string | null>(null);
@@ -65,4 +65,6 @@ export default function RaceResultFormContainer({
 			disabled={disabled}
 		/>
 	);
-}
+};
+
+export default RaceResultFormContainer;

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -5,7 +5,7 @@ import { formatDateDisplay } from "@/utils/date";
 import type { RaceResultDetailProps } from "./types";
 import { formatHorseNumbers } from "./utils";
 
-export default function RaceResultDetail({ race }: RaceResultDetailProps) {
+const RaceResultDetail = ({ race }: RaceResultDetailProps) => {
 	return (
 		<div className="flex flex-col gap-4 p-4">
 			<div className="flex items-center justify-between">
@@ -134,6 +134,8 @@ export default function RaceResultDetail({ race }: RaceResultDetailProps) {
 			</ScrollableTable>
 		</div>
 	);
-}
+};
+
+export default RaceResultDetail;
 
 export type { RaceResultDetailProps } from "./types";

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/utils.ts
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/utils.ts
@@ -5,12 +5,12 @@ const ARROW_TICKET_TYPES = ["umatan", "sanrentan"];
  * sort_order 昇順に並び替えたうえで連結する。
  * 馬単・三連単は "→"、それ以外は "-" を区切り文字として使用する。
  */
-export function formatHorseNumbers(
+export const formatHorseNumbers = (
 	horses: { horse_number: number; sort_order: number }[],
 	ticketTypeName: string,
-): string {
+): string => {
 	const sorted = [...horses].sort((a, b) => a.sort_order - b.sort_order);
 	const numbers = sorted.map((h) => h.horse_number);
 	const separator = ARROW_TICKET_TYPES.includes(ticketTypeName) ? "→" : "-";
 	return numbers.join(separator);
-}
+};

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
@@ -3,7 +3,7 @@ import AlertError from "@/components/presentational/AlertError";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceResultFormProps } from "./types";
 
-export default function RaceResultForm({
+const RaceResultForm = ({
 	venueName,
 	raceDate,
 	raceNumber,
@@ -16,7 +16,7 @@ export default function RaceResultForm({
 	onSubmit,
 	isSubmitting,
 	disabled,
-}: RaceResultFormProps) {
+}: RaceResultFormProps) => {
 	return (
 		<div className="flex flex-col gap-6 p-4">
 			<div>
@@ -81,6 +81,8 @@ export default function RaceResultForm({
 			</Button>
 		</div>
 	);
-}
+};
+
+export default RaceResultForm;
 
 export type { RaceResultFormProps } from "./types";

--- a/source/resources/js/features/settings/presentational/AppearanceTabs/index.tsx
+++ b/source/resources/js/features/settings/presentational/AppearanceTabs/index.tsx
@@ -5,10 +5,10 @@ import type { Appearance } from "@/hooks/use-appearance";
 import { useAppearance } from "@/hooks/use-appearance";
 import { cn } from "@/lib/utils";
 
-export default function AppearanceToggleTab({
+const AppearanceToggleTab = ({
 	className = "",
 	...props
-}: HTMLAttributes<HTMLDivElement>) {
+}: HTMLAttributes<HTMLDivElement>) => {
 	const { appearance, updateAppearance } = useAppearance();
 
 	const tabs: { value: Appearance; icon: LucideIcon; label: string }[] = [
@@ -43,4 +43,6 @@ export default function AppearanceToggleTab({
 			))}
 		</div>
 	);
-}
+};
+
+export default AppearanceToggleTab;

--- a/source/resources/js/features/settings/presentational/DeleteUser/index.tsx
+++ b/source/resources/js/features/settings/presentational/DeleteUser/index.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/shadcn/ui/dialog";
 import { Label } from "@/components/shadcn/ui/label";
 
-export default function DeleteUser() {
+const DeleteUser = () => {
 	const passwordInput = useRef<HTMLInputElement>(null);
 
 	return (
@@ -104,4 +104,6 @@ export default function DeleteUser() {
 			</div>
 		</div>
 	);
-}
+};
+
+export default DeleteUser;

--- a/source/resources/js/features/settings/presentational/TwoFactorRecoveryCodes/index.tsx
+++ b/source/resources/js/features/settings/presentational/TwoFactorRecoveryCodes/index.tsx
@@ -18,11 +18,11 @@ type Props = {
 	errors: string[];
 };
 
-export default function TwoFactorRecoveryCodes({
+const TwoFactorRecoveryCodes = ({
 	recoveryCodesList,
 	fetchRecoveryCodes,
 	errors,
-}: Props) {
+}: Props) => {
 	const [codesAreVisible, setCodesAreVisible] = useState<boolean>(false);
 	const codesSectionRef = useRef<HTMLUListElement | null>(null);
 	const canRegenerateCodes = recoveryCodesList.length > 0 && codesAreVisible;
@@ -147,4 +147,6 @@ export default function TwoFactorRecoveryCodes({
 			</CardContent>
 		</Card>
 	);
-}
+};
+
+export default TwoFactorRecoveryCodes;

--- a/source/resources/js/features/settings/presentational/TwoFactorSetupModal/index.tsx
+++ b/source/resources/js/features/settings/presentational/TwoFactorSetupModal/index.tsx
@@ -23,7 +23,7 @@ import { useClipboard } from "@/hooks/use-clipboard";
 import { OTP_MAX_LENGTH } from "@/hooks/use-two-factor-auth";
 import { confirm } from "@/routes/two-factor";
 
-function GridScanIcon() {
+const GridScanIcon = () => {
 	return (
 		<div className="mb-3 rounded-full border border-border bg-card p-0.5 shadow-sm">
 			<div className="relative overflow-hidden rounded-full border border-border bg-muted p-2.5">
@@ -47,9 +47,9 @@ function GridScanIcon() {
 			</div>
 		</div>
 	);
-}
+};
 
-function TwoFactorSetupStep({
+const TwoFactorSetupStep = ({
 	qrCodeSvg,
 	manualSetupKey,
 	buttonText,
@@ -61,7 +61,7 @@ function TwoFactorSetupStep({
 	buttonText: string;
 	onNextStep: () => void;
 	errors: string[];
-}) {
+}) => {
 	const { resolvedAppearance } = useAppearance();
 	const [copiedText, copy] = useClipboard();
 	const IconComponent = copiedText === manualSetupKey ? Check : Copy;
@@ -138,15 +138,15 @@ function TwoFactorSetupStep({
 			)}
 		</>
 	);
-}
+};
 
-function TwoFactorVerificationStep({
+const TwoFactorVerificationStep = ({
 	onClose,
 	onBack,
 }: {
 	onClose: () => void;
 	onBack: () => void;
-}) {
+}) => {
 	const [code, setCode] = useState<string>("");
 	const pinInputContainerRef = useRef<HTMLDivElement>(null);
 
@@ -233,7 +233,7 @@ type Props = {
 	errors: string[];
 };
 
-export default function TwoFactorSetupModal({
+const TwoFactorSetupModal = ({
 	isOpen,
 	onClose,
 	requiresConfirmation,
@@ -243,7 +243,7 @@ export default function TwoFactorSetupModal({
 	clearSetupData,
 	fetchSetupData,
 	errors,
-}: Props) {
+}: Props) => {
 	const [showVerificationStep, setShowVerificationStep] =
 		useState<boolean>(false);
 
@@ -339,4 +339,6 @@ export default function TwoFactorSetupModal({
 			</DialogContent>
 		</Dialog>
 	);
-}
+};
+
+export default TwoFactorSetupModal;

--- a/source/resources/js/features/ticket/containers/TicketPurchaseFormContainer/index.tsx
+++ b/source/resources/js/features/ticket/containers/TicketPurchaseFormContainer/index.tsx
@@ -19,7 +19,7 @@ export type TicketPurchaseFormContainerProps = {
 	initialAmount: number;
 };
 
-export default function TicketPurchaseFormContainer({
+const TicketPurchaseFormContainer = ({
 	initialVenue,
 	initialRaceDate,
 	initialRaceNumber,
@@ -29,7 +29,7 @@ export default function TicketPurchaseFormContainer({
 	initialNagashiDirection,
 	initialHorses,
 	initialAmount,
-}: TicketPurchaseFormContainerProps) {
+}: TicketPurchaseFormContainerProps) => {
 	const [selectedVenue, setSelectedVenue] = useState(initialVenue);
 	const [selectedRaceDate, setSelectedRaceDate] = useState(initialRaceDate);
 	const [selectedRaceNumber, setSelectedRaceNumber] =
@@ -113,4 +113,6 @@ export default function TicketPurchaseFormContainer({
 			/>
 		</form>
 	);
-}
+};
+
+export default TicketPurchaseFormContainer;

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseGrid.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseGrid.tsx
@@ -10,14 +10,14 @@ type HorseGridProps = {
 	onTextChange: (text: string) => void;
 };
 
-export function HorseGrid({
+export const HorseGrid = ({
 	label,
 	groupKey,
 	gridSize,
 	selectedHorses,
 	onToggle,
 	onTextChange,
-}: HorseGridProps) {
+}: HorseGridProps) => {
 	return (
 		<div className="space-y-2">
 			<div className="flex items-center gap-2">
@@ -56,4 +56,4 @@ export function HorseGrid({
 			</div>
 		</div>
 	);
-}
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseSelectionSection/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/HorseSelectionSection/index.tsx
@@ -6,7 +6,7 @@ import { Section } from "../Section";
 import { getHorseInputConfigKey } from "../utils";
 import type { HorseSelectionSectionProps } from "./types";
 
-export function HorseSelectionSection({
+export const HorseSelectionSection = ({
 	selectedTicketTypeId,
 	selectedBuyTypeId,
 	selectedAxisCount,
@@ -15,7 +15,7 @@ export function HorseSelectionSection({
 	onAxisCountChange,
 	onNagashiDirectionChange,
 	onHorsesChange,
-}: HorseSelectionSectionProps) {
+}: HorseSelectionSectionProps) => {
 	const gridSize = GRID_SIZE[selectedTicketTypeId] ?? 18;
 
 	const showAxisCountSelector =
@@ -106,4 +106,4 @@ export function HorseSelectionSection({
 			</div>
 		</Section>
 	);
-}
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/RaceInfoSection/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/RaceInfoSection/index.tsx
@@ -12,14 +12,14 @@ import { VENUES } from "../constants";
 import { Section } from "../Section";
 import type { RaceInfoSectionProps } from "./types";
 
-export function RaceInfoSection({
+export const RaceInfoSection = ({
 	selectedVenue,
 	selectedRaceDate,
 	selectedRaceNumber,
 	onVenueChange,
 	onRaceDateChange,
 	onRaceNumberChange,
-}: RaceInfoSectionProps) {
+}: RaceInfoSectionProps) => {
 	return (
 		<Section title="レース情報">
 			<div className="space-y-4">
@@ -86,4 +86,4 @@ export function RaceInfoSection({
 			</div>
 		</Section>
 	);
-}
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/Section.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/Section.tsx
@@ -3,7 +3,7 @@ type SectionProps = {
 	children: React.ReactNode;
 };
 
-export function Section({ title, children }: SectionProps) {
+export const Section = ({ title, children }: SectionProps) => {
 	return (
 		<section className="space-y-3">
 			<h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
@@ -12,4 +12,4 @@ export function Section({ title, children }: SectionProps) {
 			<div>{children}</div>
 		</section>
 	);
-}
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketTypeSelector/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketTypeSelector/index.tsx
@@ -3,12 +3,12 @@ import { BUY_TYPE_MAP, TICKET_TYPES } from "../constants";
 import { Section } from "../Section";
 import type { TicketTypeSelectorProps } from "./types";
 
-export function TicketTypeSelector({
+export const TicketTypeSelector = ({
 	selectedTicketTypeId,
 	selectedBuyTypeId,
 	onTicketTypeChange,
 	onBuyTypeChange,
-}: TicketTypeSelectorProps) {
+}: TicketTypeSelectorProps) => {
 	const buyTypes = BUY_TYPE_MAP[selectedTicketTypeId];
 
 	return (
@@ -48,4 +48,4 @@ export function TicketTypeSelector({
 			</Section>
 		</>
 	);
-}
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/index.tsx
@@ -12,7 +12,7 @@ export type { TicketTypeId } from "./constants";
 export { getHorseInputConfigKey } from "./utils";
 export type { TicketPurchaseFormProps } from "./types";
 
-export default function TicketPurchaseForm({
+const TicketPurchaseForm = ({
 	selectedVenue,
 	selectedRaceDate,
 	selectedRaceNumber,
@@ -32,7 +32,7 @@ export default function TicketPurchaseForm({
 	onNagashiDirectionChange,
 	onHorsesChange,
 	onAmountChange,
-}: TicketPurchaseFormProps) {
+}: TicketPurchaseFormProps) => {
 	return (
 		<div className="mx-auto max-w-2xl space-y-8 p-4">
 			<RaceInfoSection
@@ -123,4 +123,6 @@ export default function TicketPurchaseForm({
 			</div>
 		</div>
 	);
-}
+};
+
+export default TicketPurchaseForm;

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/utils.ts
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/utils.ts
@@ -1,11 +1,11 @@
 import type { TicketTypeId } from "./constants";
 
-export function getHorseInputConfigKey(
+export const getHorseInputConfigKey = (
 	ticketTypeId: TicketTypeId,
 	buyTypeId: string,
 	axisCount: 1 | 2,
 	_nagashiDirection: 1 | 2 | 3,
-): string {
+): string => {
 	const showNagashiDirectionSelector =
 		buyTypeId === "nagashi" && ticketTypeId === "sanrentan";
 
@@ -18,4 +18,4 @@ export function getHorseInputConfigKey(
 		return "formation_sanrenpuku";
 	}
 	return buyTypeId;
-}
+};

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseList/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseList/index.tsx
@@ -7,12 +7,12 @@ import { formatDateDisplay } from "@/utils/date";
 import type { TicketPurchaseListProps } from "./types";
 import { formatSelections } from "./utils";
 
-export default function TicketPurchaseList({
+const TicketPurchaseList = ({
 	purchases,
 	hasMore,
 	isLoading,
 	onLoadMore,
-}: TicketPurchaseListProps) {
+}: TicketPurchaseListProps) => {
 	return (
 		<div className="flex flex-col gap-4 p-4">
 			<div className="flex items-center justify-between">
@@ -133,6 +133,8 @@ export default function TicketPurchaseList({
 			)}
 		</div>
 	);
-}
+};
+
+export default TicketPurchaseList;
 
 export type { TicketPurchaseListItem, TicketPurchaseListProps } from "./types";

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseList/utils.ts
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseList/utils.ts
@@ -9,7 +9,7 @@ import type { Selections } from "./types";
  * - columns形式: "1,2 - 3,4 - 5,6,7"
  * @param selections - DBから取得した馬番選択情報（JSON）
  */
-export function formatSelections(selections: Selections): string {
+export const formatSelections = (selections: Selections): string => {
 	if ("horses" in selections) {
 		return selections.horses.join("-");
 	}
@@ -34,4 +34,4 @@ export function formatSelections(selections: Selections): string {
 			.join(" - ");
 	}
 	return selections.columns.map((col) => col.join(",")).join(" - ");
-}
+};

--- a/source/resources/js/hooks/use-appearance.tsx
+++ b/source/resources/js/hooks/use-appearance.tsx
@@ -74,7 +74,7 @@ const mediaQuery = (): MediaQueryList | null => {
 
 const handleSystemThemeChange = (): void => applyTheme(currentAppearance);
 
-export function initializeTheme(): void {
+export const initializeTheme = (): void => {
 	if (typeof window === "undefined") {
 		return;
 	}
@@ -89,9 +89,9 @@ export function initializeTheme(): void {
 
 	// Set up system theme change listener
 	mediaQuery()?.addEventListener("change", handleSystemThemeChange);
-}
+};
 
-export function useAppearance(): UseAppearanceReturn {
+export const useAppearance = (): UseAppearanceReturn => {
 	const appearance: Appearance = useSyncExternalStore(
 		subscribe,
 		() => currentAppearance,
@@ -116,4 +116,4 @@ export function useAppearance(): UseAppearanceReturn {
 	};
 
 	return { appearance, resolvedAppearance, updateAppearance } as const;
-}
+};

--- a/source/resources/js/hooks/use-clipboard.ts
+++ b/source/resources/js/hooks/use-clipboard.ts
@@ -5,7 +5,7 @@ export type CopiedValue = string | null;
 export type CopyFn = (text: string) => Promise<boolean>;
 export type UseClipboardReturn = [CopiedValue, CopyFn];
 
-export function useClipboard(): UseClipboardReturn {
+export const useClipboard = (): UseClipboardReturn => {
 	const [copiedText, setCopiedText] = useState<CopiedValue>(null);
 
 	const copy: CopyFn = async (text) => {
@@ -29,4 +29,4 @@ export function useClipboard(): UseClipboardReturn {
 	};
 
 	return [copiedText, copy];
-}
+};

--- a/source/resources/js/hooks/use-current-url.ts
+++ b/source/resources/js/hooks/use-current-url.ts
@@ -26,7 +26,7 @@ export type UseCurrentUrlReturn = {
 	whenCurrentUrl: WhenCurrentUrlFn;
 };
 
-export function useCurrentUrl(): UseCurrentUrlReturn {
+export const useCurrentUrl = (): UseCurrentUrlReturn => {
 	const page = usePage();
 	const currentUrlPath = new URL(
 		page.url,
@@ -78,4 +78,4 @@ export function useCurrentUrl(): UseCurrentUrlReturn {
 		isCurrentOrParentUrl,
 		whenCurrentUrl,
 	};
-}
+};

--- a/source/resources/js/hooks/use-initials.tsx
+++ b/source/resources/js/hooks/use-initials.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 
 export type GetInitialsFn = (fullName: string) => string;
 
-export function useInitials(): GetInitialsFn {
+export const useInitials = (): GetInitialsFn => {
 	return useCallback((fullName: string): string => {
 		const names = fullName.trim().split(" ");
 
@@ -19,4 +19,4 @@ export function useInitials(): GetInitialsFn {
 
 		return `${firstInitial}${lastInitial}`.toUpperCase();
 	}, []);
-}
+};

--- a/source/resources/js/hooks/use-mobile-navigation.ts
+++ b/source/resources/js/hooks/use-mobile-navigation.ts
@@ -2,9 +2,9 @@ import { useCallback } from "react";
 
 export type CleanupFn = () => void;
 
-export function useMobileNavigation(): CleanupFn {
+export const useMobileNavigation = (): CleanupFn => {
 	return useCallback(() => {
 		// Remove pointer-events style from body...
 		document.body.style.removeProperty("pointer-events");
 	}, []);
-}
+};

--- a/source/resources/js/hooks/use-mobile.tsx
+++ b/source/resources/js/hooks/use-mobile.tsx
@@ -7,7 +7,7 @@ const mql =
 		? undefined
 		: window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
 
-function mediaQueryListener(callback: (event: MediaQueryListEvent) => void) {
+const mediaQueryListener = (callback: (event: MediaQueryListEvent) => void) => {
 	if (!mql) {
 		return () => {};
 	}
@@ -17,20 +17,20 @@ function mediaQueryListener(callback: (event: MediaQueryListEvent) => void) {
 	return () => {
 		mql.removeEventListener("change", callback);
 	};
-}
+};
 
-function isSmallerThanBreakpoint(): boolean {
+const isSmallerThanBreakpoint = (): boolean => {
 	return mql?.matches ?? false;
-}
+};
 
-function getServerSnapshot(): boolean {
+const getServerSnapshot = (): boolean => {
 	return false;
-}
+};
 
-export function useIsMobile(): boolean {
+export const useIsMobile = (): boolean => {
 	return useSyncExternalStore(
 		mediaQueryListener,
 		isSmallerThanBreakpoint,
 		getServerSnapshot,
 	);
-}
+};

--- a/source/resources/js/hooks/useDebouncedCallback.ts
+++ b/source/resources/js/hooks/useDebouncedCallback.ts
@@ -7,13 +7,13 @@ import { useCallback, useEffect, useRef } from "react";
  *
  * 失敗時の state ロールバックを行わない用途を想定（入力中の最新値を捨てると UX が悪いため）。
  */
-export function useDebouncedCallbackByKey<TArgs extends unknown[]>(
+export const useDebouncedCallbackByKey = <TArgs extends unknown[]>(
 	fn: (...args: TArgs) => void,
 	delayMs: number,
 ): {
 	call: (key: string | number, ...args: TArgs) => void;
 	cancel: (key: string | number) => void;
-} {
+} => {
 	const fnRef = useRef(fn);
 	fnRef.current = fn;
 	const timersRef = useRef(
@@ -52,4 +52,4 @@ export function useDebouncedCallbackByKey<TArgs extends unknown[]>(
 	}, []);
 
 	return { call, cancel };
-}
+};

--- a/source/resources/js/layouts/app-layout.tsx
+++ b/source/resources/js/layouts/app-layout.tsx
@@ -1,14 +1,16 @@
 import AppLayoutTemplate from "@/layouts/app/app-sidebar-layout";
 import type { BreadcrumbItem } from "@/types";
 
-export default function AppLayout({
+const AppLayout = ({
 	breadcrumbs = [],
 	children,
 }: {
 	breadcrumbs?: BreadcrumbItem[];
 	children: React.ReactNode;
-}) {
+}) => {
 	return (
 		<AppLayoutTemplate breadcrumbs={breadcrumbs}>{children}</AppLayoutTemplate>
 	);
-}
+};
+
+export default AppLayout;

--- a/source/resources/js/layouts/app/app-header-layout.tsx
+++ b/source/resources/js/layouts/app/app-header-layout.tsx
@@ -3,14 +3,13 @@ import { AppHeader } from "@/components/presentational/AppHeader";
 import { AppShell } from "@/components/presentational/AppShell";
 import type { AppLayoutProps } from "@/types";
 
-export default function AppHeaderLayout({
-	children,
-	breadcrumbs,
-}: AppLayoutProps) {
+const AppHeaderLayout = ({ children, breadcrumbs }: AppLayoutProps) => {
 	return (
 		<AppShell variant="header">
 			<AppHeader breadcrumbs={breadcrumbs} />
 			<AppContent variant="header">{children}</AppContent>
 		</AppShell>
 	);
-}
+};
+
+export default AppHeaderLayout;

--- a/source/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/source/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -4,10 +4,10 @@ import { AppSidebar } from "@/components/presentational/AppSidebar";
 import { AppSidebarHeader } from "@/components/presentational/AppSidebarHeader";
 import type { AppLayoutProps } from "@/types";
 
-export default function AppSidebarLayout({
+const AppSidebarLayout = ({
 	children,
 	breadcrumbs = [],
-}: AppLayoutProps) {
+}: AppLayoutProps) => {
 	return (
 		<AppShell variant="sidebar">
 			<AppSidebar />
@@ -17,4 +17,6 @@ export default function AppSidebarLayout({
 			</AppContent>
 		</AppShell>
 	);
-}
+};
+
+export default AppSidebarLayout;

--- a/source/resources/js/layouts/auth-layout.tsx
+++ b/source/resources/js/layouts/auth-layout.tsx
@@ -1,6 +1,6 @@
 import AuthLayoutTemplate from "@/layouts/auth/auth-simple-layout";
 
-export default function AuthLayout({
+const AuthLayout = ({
 	title = "",
 	description = "",
 	children,
@@ -8,10 +8,12 @@ export default function AuthLayout({
 	title?: string;
 	description?: string;
 	children: React.ReactNode;
-}) {
+}) => {
 	return (
 		<AuthLayoutTemplate title={title} description={description}>
 			{children}
 		</AuthLayoutTemplate>
 	);
-}
+};
+
+export default AuthLayout;

--- a/source/resources/js/layouts/auth/auth-card-layout.tsx
+++ b/source/resources/js/layouts/auth/auth-card-layout.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/shadcn/ui/card";
 import { home } from "@/routes";
 
-export default function AuthCardLayout({
+const AuthCardLayout = ({
 	children,
 	title,
 	description,
@@ -18,7 +18,7 @@ export default function AuthCardLayout({
 	name?: string;
 	title?: string;
 	description?: string;
-}>) {
+}>) => {
 	return (
 		<div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
 			<div className="flex w-full max-w-md flex-col gap-6">
@@ -43,4 +43,6 @@ export default function AuthCardLayout({
 			</div>
 		</div>
 	);
-}
+};
+
+export default AuthCardLayout;

--- a/source/resources/js/layouts/auth/auth-simple-layout.tsx
+++ b/source/resources/js/layouts/auth/auth-simple-layout.tsx
@@ -3,11 +3,11 @@ import AppLogoIcon from "@/components/presentational/AppLogoIcon";
 import { home } from "@/routes";
 import type { AuthLayoutProps } from "@/types";
 
-export default function AuthSimpleLayout({
+const AuthSimpleLayout = ({
 	children,
 	title,
 	description,
-}: AuthLayoutProps) {
+}: AuthLayoutProps) => {
 	return (
 		<div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6 md:p-10">
 			<div className="w-full max-w-sm">
@@ -35,4 +35,6 @@ export default function AuthSimpleLayout({
 			</div>
 		</div>
 	);
-}
+};
+
+export default AuthSimpleLayout;

--- a/source/resources/js/layouts/auth/auth-split-layout.tsx
+++ b/source/resources/js/layouts/auth/auth-split-layout.tsx
@@ -3,11 +3,11 @@ import AppLogoIcon from "@/components/presentational/AppLogoIcon";
 import { home } from "@/routes";
 import type { AuthLayoutProps } from "@/types";
 
-export default function AuthSplitLayout({
+const AuthSplitLayout = ({
 	children,
 	title,
 	description,
-}: AuthLayoutProps) {
+}: AuthLayoutProps) => {
 	const { name } = usePage().props;
 
 	return (
@@ -41,4 +41,6 @@ export default function AuthSplitLayout({
 			</div>
 		</div>
 	);
-}
+};
+
+export default AuthSplitLayout;

--- a/source/resources/js/layouts/settings/layout.tsx
+++ b/source/resources/js/layouts/settings/layout.tsx
@@ -28,7 +28,7 @@ const sidebarNavItems: NavItem[] = [
 	},
 ];
 
-export default function SettingsLayout({ children }: PropsWithChildren) {
+const SettingsLayout = ({ children }: PropsWithChildren) => {
 	const { isCurrentOrParentUrl } = useCurrentUrl();
 
 	return (
@@ -71,4 +71,6 @@ export default function SettingsLayout({ children }: PropsWithChildren) {
 			</div>
 		</div>
 	);
-}
+};
+
+export default SettingsLayout;

--- a/source/resources/js/lib/utils.ts
+++ b/source/resources/js/lib/utils.ts
@@ -3,10 +3,10 @@ import { clsx } from "clsx";
 import type { ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-export function cn(...inputs: ClassValue[]) {
+export const cn = (...inputs: ClassValue[]) => {
 	return twMerge(clsx(inputs));
-}
+};
 
-export function toUrl(url: NonNullable<InertiaLinkProps["href"]>): string {
+export const toUrl = (url: NonNullable<InertiaLinkProps["href"]>): string => {
 	return typeof url === "string" ? url : url.url;
-}
+};

--- a/source/resources/js/pages/auth/confirm-password.tsx
+++ b/source/resources/js/pages/auth/confirm-password.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/shadcn/ui/label";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { store } from "@/routes/password/confirm";
 
-export default function ConfirmPassword() {
+const ConfirmPassword = () => {
 	return (
 		<>
 			<Head title="Confirm password" />
@@ -42,7 +42,9 @@ export default function ConfirmPassword() {
 			</Form>
 		</>
 	);
-}
+};
+
+export default ConfirmPassword;
 
 ConfirmPassword.layout = {
 	title: "Confirm your password",

--- a/source/resources/js/pages/auth/login.tsx
+++ b/source/resources/js/pages/auth/login.tsx
@@ -14,7 +14,7 @@ type Props = {
 	canRegister: boolean;
 };
 
-export default function Login({ status }: Props) {
+const Login = ({ status }: Props) => {
 	return (
 		<>
 			<Head title="Log in" />
@@ -78,7 +78,9 @@ export default function Login({ status }: Props) {
 			)}
 		</>
 	);
-}
+};
+
+export default Login;
 
 Login.layout = {
 	title: "Log in to your account",

--- a/source/resources/js/pages/auth/reset-password.tsx
+++ b/source/resources/js/pages/auth/reset-password.tsx
@@ -12,7 +12,7 @@ type Props = {
 	email: string;
 };
 
-export default function ResetPassword({ token, email }: Props) {
+const ResetPassword = ({ token, email }: Props) => {
 	return (
 		<>
 			<Head title="Reset password" />
@@ -80,7 +80,9 @@ export default function ResetPassword({ token, email }: Props) {
 			</Form>
 		</>
 	);
-}
+};
+
+export default ResetPassword;
 
 ResetPassword.layout = {
 	title: "Reset password",

--- a/source/resources/js/pages/auth/two-factor-challenge.tsx
+++ b/source/resources/js/pages/auth/two-factor-challenge.tsx
@@ -12,7 +12,7 @@ import {
 import { OTP_MAX_LENGTH } from "@/hooks/use-two-factor-auth";
 import { store } from "@/routes/two-factor/login";
 
-export default function TwoFactorChallenge() {
+const TwoFactorChallenge = () => {
 	const [showRecoveryInput, setShowRecoveryInput] = useState<boolean>(false);
 	const [code, setCode] = useState<string>("");
 
@@ -119,4 +119,6 @@ export default function TwoFactorChallenge() {
 			</div>
 		</>
 	);
-}
+};
+
+export default TwoFactorChallenge;

--- a/source/resources/js/pages/auth/verify-email.tsx
+++ b/source/resources/js/pages/auth/verify-email.tsx
@@ -6,7 +6,7 @@ import { Spinner } from "@/components/shadcn/ui/spinner";
 import { logout } from "@/routes";
 import { send } from "@/routes/verification";
 
-export default function VerifyEmail({ status }: { status?: string }) {
+const VerifyEmail = ({ status }: { status?: string }) => {
 	return (
 		<>
 			<Head title="Email verification" />
@@ -34,7 +34,9 @@ export default function VerifyEmail({ status }: { status?: string }) {
 			</Form>
 		</>
 	);
-}
+};
+
+export default VerifyEmail;
 
 VerifyEmail.layout = {
 	title: "Verify email",

--- a/source/resources/js/pages/dashboard.tsx
+++ b/source/resources/js/pages/dashboard.tsx
@@ -13,7 +13,7 @@ type DashboardPageProps = {
 	daily_balances: DailyBalance[];
 };
 
-export default function Dashboard() {
+const Dashboard = () => {
 	const { selected_year, available_years, summary, daily_balances } =
 		usePage<DashboardPageProps>().props;
 
@@ -37,7 +37,9 @@ export default function Dashboard() {
 			/>
 		</>
 	);
-}
+};
+
+export default Dashboard;
 
 Dashboard.layout = {
 	breadcrumbs: [

--- a/source/resources/js/pages/horses/show.tsx
+++ b/source/resources/js/pages/horses/show.tsx
@@ -6,7 +6,7 @@ type HorsesShowProps = {
 	horse: HorseDetailItem;
 };
 
-export default function HorsesShow() {
+const HorsesShow = () => {
 	const { horse } = usePage<HorsesShowProps>().props;
 
 	return (
@@ -15,4 +15,6 @@ export default function HorsesShow() {
 			<HorseDetail horse={horse} />
 		</>
 	);
-}
+};
+
+export default HorsesShow;

--- a/source/resources/js/pages/races/entries/new.tsx
+++ b/source/resources/js/pages/races/entries/new.tsx
@@ -7,7 +7,7 @@ type RacesEntriesNewProps = {
 	race_info: RaceInfo;
 };
 
-export default function RacesEntriesNew() {
+const RacesEntriesNew = () => {
 	const { race_uid, race_info } = usePage<RacesEntriesNewProps>().props;
 
 	return (
@@ -19,4 +19,6 @@ export default function RacesEntriesNew() {
 			/>
 		</>
 	);
-}
+};
+
+export default RacesEntriesNew;

--- a/source/resources/js/pages/races/index.tsx
+++ b/source/resources/js/pages/races/index.tsx
@@ -28,7 +28,7 @@ const buildQuery = (date: string, venueId: string) => {
 	return query;
 };
 
-export default function RacesIndex() {
+const RacesIndex = () => {
 	const { races, venues, filters } = usePage<RacesIndexProps>().props;
 
 	const [selectedDate, setSelectedDate] = useState<string>(
@@ -89,4 +89,6 @@ export default function RacesIndex() {
 			/>
 		</>
 	);
-}
+};
+
+export default RacesIndex;

--- a/source/resources/js/pages/races/new.tsx
+++ b/source/resources/js/pages/races/new.tsx
@@ -8,7 +8,7 @@ type RacesNewProps = {
 	last_race_number?: number;
 };
 
-export default function RacesNew() {
+const RacesNew = () => {
 	const { venues, last_venue_id, last_race_date, last_race_number } =
 		usePage<RacesNewProps>().props;
 
@@ -23,4 +23,6 @@ export default function RacesNew() {
 			/>
 		</>
 	);
-}
+};
+
+export default RacesNew;

--- a/source/resources/js/pages/races/result/create.tsx
+++ b/source/resources/js/pages/races/result/create.tsx
@@ -11,7 +11,7 @@ type RaceResultCreateProps = {
 	};
 };
 
-export default function RaceResultCreate() {
+const RaceResultCreate = () => {
 	const { race } = usePage<RaceResultCreateProps>().props;
 
 	return (
@@ -26,4 +26,6 @@ export default function RaceResultCreate() {
 			/>
 		</>
 	);
-}
+};
+
+export default RaceResultCreate;

--- a/source/resources/js/pages/races/result/edit.tsx
+++ b/source/resources/js/pages/races/result/edit.tsx
@@ -6,7 +6,7 @@ type RaceResultEditProps = {
 	race: RaceResultDetailProps["race"];
 };
 
-export default function RaceResultEdit() {
+const RaceResultEdit = () => {
 	const { race } = usePage<RaceResultEditProps>().props;
 
 	return (
@@ -15,4 +15,6 @@ export default function RaceResultEdit() {
 			<RaceResultDetail race={race} />
 		</>
 	);
-}
+};
+
+export default RaceResultEdit;

--- a/source/resources/js/pages/races/show.tsx
+++ b/source/resources/js/pages/races/show.tsx
@@ -6,7 +6,7 @@ type RacesShowProps = {
 	race: RaceDetailItem;
 };
 
-export default function RacesShow() {
+const RacesShow = () => {
 	const { race } = usePage<RacesShowProps>().props;
 
 	return (
@@ -15,4 +15,6 @@ export default function RacesShow() {
 			<RaceDetailContainer race={race} />
 		</>
 	);
-}
+};
+
+export default RacesShow;

--- a/source/resources/js/pages/settings/appearance.tsx
+++ b/source/resources/js/pages/settings/appearance.tsx
@@ -3,7 +3,7 @@ import AppearanceTabs from "@/features/settings/presentational/AppearanceTabs";
 import Heading from "@/components/presentational/Heading";
 import { edit as editAppearance } from "@/routes/appearance";
 
-export default function Appearance() {
+const Appearance = () => {
 	return (
 		<>
 			<Head title="Appearance settings" />
@@ -20,7 +20,9 @@ export default function Appearance() {
 			</div>
 		</>
 	);
-}
+};
+
+export default Appearance;
 
 Appearance.layout = {
 	breadcrumbs: [

--- a/source/resources/js/pages/settings/profile.tsx
+++ b/source/resources/js/pages/settings/profile.tsx
@@ -10,13 +10,13 @@ import { Label } from "@/components/shadcn/ui/label";
 import { edit } from "@/routes/profile";
 import { send } from "@/routes/verification";
 
-export default function Profile({
+const Profile = ({
 	mustVerifyEmail,
 	status,
 }: {
 	mustVerifyEmail: boolean;
 	status?: string;
-}) {
+}) => {
 	const { auth } = usePage().props;
 
 	return (
@@ -119,7 +119,9 @@ export default function Profile({
 			<DeleteUser />
 		</>
 	);
-}
+};
+
+export default Profile;
 
 Profile.layout = {
 	breadcrumbs: [

--- a/source/resources/js/pages/settings/security.tsx
+++ b/source/resources/js/pages/settings/security.tsx
@@ -20,11 +20,11 @@ type Props = {
 	twoFactorEnabled?: boolean;
 };
 
-export default function Security({
+const Security = ({
 	canManageTwoFactor = false,
 	requiresConfirmation = false,
 	twoFactorEnabled = false,
-}: Props) {
+}: Props) => {
 	const passwordInput = useRef<HTMLInputElement>(null);
 	const currentPasswordInput = useRef<HTMLInputElement>(null);
 
@@ -234,7 +234,9 @@ export default function Security({
 			)}
 		</>
 	);
-}
+};
+
+export default Security;
 
 Security.layout = {
 	breadcrumbs: [

--- a/source/resources/js/pages/tickets/index.tsx
+++ b/source/resources/js/pages/tickets/index.tsx
@@ -8,7 +8,7 @@ type TicketsIndexProps = {
 	nextCursor: string | null;
 };
 
-export default function TicketsIndex() {
+const TicketsIndex = () => {
 	const { purchases, nextCursor } = usePage<TicketsIndexProps>().props;
 	const [isLoading, setIsLoading] = useState(false);
 
@@ -33,4 +33,6 @@ export default function TicketsIndex() {
 			/>
 		</>
 	);
-}
+};
+
+export default TicketsIndex;

--- a/source/resources/js/pages/tickets/new.tsx
+++ b/source/resources/js/pages/tickets/new.tsx
@@ -7,7 +7,7 @@ type TicketsNewProps = {
 	lastRaceNumber: number;
 };
 
-export default function TicketsNew() {
+const TicketsNew = () => {
 	const { lastVenue, lastRaceDate, lastRaceNumber } =
 		usePage<TicketsNewProps>().props;
 
@@ -27,4 +27,6 @@ export default function TicketsNew() {
 			/>
 		</>
 	);
-}
+};
+
+export default TicketsNew;

--- a/source/resources/js/pages/welcome.tsx
+++ b/source/resources/js/pages/welcome.tsx
@@ -1,11 +1,11 @@
 import { Head, Link, usePage } from "@inertiajs/react";
 import { dashboard, login, register } from "@/routes";
 
-export default function Welcome({
+const Welcome = ({
 	canRegister = true,
 }: {
 	canRegister?: boolean;
-}) {
+}) => {
 	const { auth } = usePage().props;
 
 	return (
@@ -52,4 +52,6 @@ export default function Welcome({
 			</div>
 		</>
 	);
-}
+};
+
+export default Welcome;

--- a/source/resources/js/utils/date.ts
+++ b/source/resources/js/utils/date.ts
@@ -8,6 +8,6 @@
  *               想定外の形式が渡された場合はハイフンのみがスラッシュに置換される。
  * @returns `YYYY/MM/DD` 形式に変換された日付文字列。
  */
-export function formatDateDisplay(date: string): string {
+export const formatDateDisplay = (date: string): string => {
 	return date.replace(/-/g, "/");
-}
+};


### PR DESCRIPTION
closes #186

## やったこと

- `docs/architecture/frontend/naming-conventions.md` に「関数定義はアロー関数を使用」ルールを1行追記
- `source/biome.json` に `complexity.useArrowFunction: error` を追加し、Biome で関数式 → アロー関数を強制
- `resources/js/` 配下の手書きコード全 86 ファイルを以下4コミットに分割してアロー関数化
  - pages/ + layouts/（27ファイル）
  - components/presentational/ + features/（50ファイル）
  - hooks/ + lib/ + utils/（9ファイル）
- `export default function Foo()` → `const Foo = () => {}; export default Foo;` の形式に変換
- 自動生成・サードパーティ由来のコード（`shadcn/ui`, `actions/`, `routes/`, `wayfinder/`）は対象外（biome.json の files.ignore で既に除外済み）

## 結果

ローカルでの検証結果:

- Biome lint: 156 ファイル チェック、エラーなし
- TypeScript 型チェック (`tsc --noEmit`): エラーなし
- Vitest: 44 ファイル / 279 テストすべて通過
- 残存する関数宣言: 0件（除外ディレクトリを除く）

## 動作確認済み

- [x] Biome lint が通る
- [x] TypeScript 型チェックが通る
- [x] Vitest 全テスト通過
- [ ] Sail (Docker) を起動してブラウザでの主要画面動作確認（ローカルで Docker が起動できなかったため未実施。CI / レビュアー側で確認をお願いします）