### PR TITLE
[minor] 各画面に戻るボタンを追加

### DIFF
--- a/source/resources/js/components/presentational/BackButton/index.stories.tsx
+++ b/source/resources/js/components/presentational/BackButton/index.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BackButton from ".";
+
+const meta: Meta<typeof BackButton> = {
+	title: "components/presentational/BackButton",
+	component: BackButton,
+};
+
+export default meta;
+type Story = StoryObj<typeof BackButton>;
+
+export const WithHref: Story = {
+	name: "リンク遷移（戻り先固定）",
+	args: {
+		label: "レース結果へ戻る",
+		href: "/races/test-uid/result/edit",
+	},
+};
+
+export const BrowserBack: Story = {
+	name: "ブラウザback（戻り先動的）",
+	args: {
+		label: "戻る",
+	},
+};

--- a/source/resources/js/components/presentational/BackButton/index.tsx
+++ b/source/resources/js/components/presentational/BackButton/index.tsx
@@ -1,0 +1,35 @@
+import { Link } from "@inertiajs/react";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/shadcn/ui/button";
+
+type Props = {
+	label: string;
+	href?: string;
+};
+
+const BackButton = ({ label, href }: Props) => {
+	if (href !== undefined) {
+		return (
+			<Button asChild variant="outline" size="sm">
+				<Link href={href}>
+					<ArrowLeft />
+					{label}
+				</Link>
+			</Button>
+		);
+	}
+
+	return (
+		<Button
+			type="button"
+			variant="outline"
+			size="sm"
+			onClick={() => window.history.back()}
+		>
+			<ArrowLeft />
+			{label}
+		</Button>
+	);
+};
+
+export default BackButton;

--- a/source/resources/js/components/presentational/BackButton/index.unit.test.tsx
+++ b/source/resources/js/components/presentational/BackButton/index.unit.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import BackButton from "./index";
+
+vi.mock("@inertiajs/react", () => ({
+	Link: ({
+		href,
+		children,
+	}: {
+		href: string;
+		children: React.ReactNode;
+	}) => <a href={href}>{children}</a>,
+}));
+
+describe("BackButton", () => {
+	describe("href が指定されているとき", () => {
+		it("リンク要素としてレンダリングされる", () => {
+			// Act
+			render(<BackButton label="戻る" href="/races" />);
+
+			// Assert
+			expect(screen.getByRole("link")).toBeInTheDocument();
+		});
+
+		it("リンクの href 属性に指定した値が設定されている", () => {
+			// Act
+			render(<BackButton label="戻る" href="/races" />);
+
+			// Assert
+			expect(screen.getByRole("link")).toHaveAttribute("href", "/races");
+		});
+
+		it("children として渡したラベルが表示される", () => {
+			// Act
+			render(<BackButton label="レース一覧へ戻る" href="/races" />);
+
+			// Assert
+			expect(screen.getByText("レース一覧へ戻る")).toBeInTheDocument();
+		});
+	});
+
+	describe("href が指定されていないとき", () => {
+		it("ボタン要素としてレンダリングされる", () => {
+			// Act
+			render(<BackButton label="戻る" />);
+
+			// Assert
+			expect(screen.getByRole("button", { name: "戻る" })).toBeInTheDocument();
+		});
+
+		it("クリックすると window.history.back が呼ばれる", async () => {
+			// Arrange
+			const backSpy = vi
+				.spyOn(window.history, "back")
+				.mockImplementation(() => {});
+			const user = userEvent.setup();
+
+			// Act
+			render(<BackButton label="戻る" />);
+			await user.click(screen.getByRole("button", { name: "戻る" }));
+
+			// Assert
+			expect(backSpy).toHaveBeenCalledTimes(1);
+			backSpy.mockRestore();
+		});
+
+		it("ラベルが表示される", () => {
+			// Act
+			render(<BackButton label="戻る" />);
+
+			// Assert
+			expect(screen.getByText("戻る")).toBeInTheDocument();
+		});
+	});
+});

--- a/source/resources/js/features/horseDetail/presentational/HorseDetail/HorseDetail.unit.test.tsx
+++ b/source/resources/js/features/horseDetail/presentational/HorseDetail/HorseDetail.unit.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 import HorseDetail from "./index";
 import type { HorseDetailProps, RaceHistoryItem } from "./types";
 
@@ -196,6 +197,34 @@ describe("HorseDetail", () => {
 
 			// Assert
 			expect(screen.getByText("東京優駿")).toBeInTheDocument();
+		});
+	});
+
+	describe("戻るボタン", () => {
+		it("「戻る」ボタンが表示される", () => {
+			// Act
+			render(<HorseDetail {...baseProps} />);
+
+			// Assert
+			expect(
+				screen.getByRole("button", { name: "戻る" }),
+			).toBeInTheDocument();
+		});
+
+		it("「戻る」ボタンをクリックすると window.history.back が呼ばれる", async () => {
+			// Arrange
+			const backSpy = vi
+				.spyOn(window.history, "back")
+				.mockImplementation(() => {});
+			const user = userEvent.setup();
+
+			// Act
+			render(<HorseDetail {...baseProps} />);
+			await user.click(screen.getByRole("button", { name: "戻る" }));
+
+			// Assert
+			expect(backSpy).toHaveBeenCalledTimes(1);
+			backSpy.mockRestore();
 		});
 	});
 });

--- a/source/resources/js/features/horseDetail/presentational/HorseDetail/index.tsx
+++ b/source/resources/js/features/horseDetail/presentational/HorseDetail/index.tsx
@@ -1,3 +1,4 @@
+import BackButton from "@/components/presentational/BackButton";
 import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { formatDateDisplay } from "@/utils/date";
 import type { HorseDetailProps } from "./types";
@@ -5,6 +6,9 @@ import type { HorseDetailProps } from "./types";
 const HorseDetail = ({ horse }: HorseDetailProps) => {
 	return (
 		<div className="flex flex-col gap-4 p-4">
+			<div>
+				<BackButton label="戻る" />
+			</div>
 			<h1 className="text-xl font-semibold">競走馬詳細</h1>
 
 			<ScrollableTable>

--- a/source/resources/js/features/raceEntry/containers/RaceEntryRegistrationFormContainer/RaceEntryRegistrationFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceEntry/containers/RaceEntryRegistrationFormContainer/RaceEntryRegistrationFormContainer.int.test.tsx
@@ -7,6 +7,13 @@ vi.mock("@inertiajs/react", () => ({
 	router: {
 		post: vi.fn(),
 	},
+	Link: ({
+		href,
+		children,
+	}: {
+		href: string;
+		children: React.ReactNode;
+	}) => <a href={href}>{children}</a>,
 }));
 
 import { router } from "@inertiajs/react";

--- a/source/resources/js/features/raceEntry/containers/RaceEntryRegistrationFormContainer/index.tsx
+++ b/source/resources/js/features/raceEntry/containers/RaceEntryRegistrationFormContainer/index.tsx
@@ -38,6 +38,7 @@ const RaceEntryRegistrationFormContainer = ({
 
 	return (
 		<RaceEntryRegistrationForm
+			raceUid={raceUid}
 			raceInfo={raceInfo}
 			pastedText={pastedText}
 			isSubmitting={isSubmitting}

--- a/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/RaceEntryRegistrationForm.unit.test.tsx
+++ b/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/RaceEntryRegistrationForm.unit.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import RaceEntryRegistrationForm from "./index";
+import type { RaceEntryRegistrationFormProps } from "./types";
+
+vi.mock("@inertiajs/react", () => ({
+	Link: ({
+		href,
+		children,
+	}: {
+		href: string;
+		children: React.ReactNode;
+	}) => <a href={href}>{children}</a>,
+}));
+
+const baseProps: RaceEntryRegistrationFormProps = {
+	raceUid: "test-race-uid",
+	raceInfo: {
+		race_date: "2026-04-05",
+		venue_name: "東京",
+		race_number: 1,
+	},
+	pastedText: "",
+	isSubmitting: false,
+	onPastedTextChange: vi.fn(),
+	onSubmit: vi.fn(),
+};
+
+describe("RaceEntryRegistrationForm", () => {
+	describe("戻るボタン", () => {
+		it("raceUid prop が渡されたとき「レース詳細へ戻る」テキストのリンクが表示される", () => {
+			// Act
+			render(<RaceEntryRegistrationForm {...baseProps} />);
+
+			// Assert
+			expect(
+				screen.getByRole("link", { name: "レース詳細へ戻る" }),
+			).toBeInTheDocument();
+		});
+
+		it("「レース詳細へ戻る」リンクの href が `/races/{raceUid}` になっている", () => {
+			// Act
+			render(<RaceEntryRegistrationForm {...baseProps} />);
+
+			// Assert
+			const link = screen.getByRole("link", { name: "レース詳細へ戻る" });
+			expect(link).toHaveAttribute("href", "/races/test-race-uid");
+		});
+	});
+});

--- a/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.stories.tsx
+++ b/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.stories.tsx
@@ -11,6 +11,7 @@ export default meta;
 type Story = StoryObj<typeof RaceEntryRegistrationForm>;
 
 const baseArgs: RaceEntryRegistrationFormProps = {
+	raceUid: "test-race-uid-123",
 	raceInfo: {
 		race_date: "2026-04-26",
 		venue_name: "東京",

--- a/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.tsx
+++ b/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.tsx
@@ -1,11 +1,13 @@
-import { Button } from "@/components/shadcn/ui/button";
+import BackButton from "@/components/presentational/BackButton";
 import ScrollableTable from "@/components/presentational/ScrollableTable";
+import { Button } from "@/components/shadcn/ui/button";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceEntryRegistrationFormProps } from "./types";
 
 export type { RaceEntryRegistrationFormProps } from "./types";
 
 const RaceEntryRegistrationForm = ({
+	raceUid,
 	raceInfo,
 	pastedText,
 	isSubmitting,
@@ -14,6 +16,10 @@ const RaceEntryRegistrationForm = ({
 }: RaceEntryRegistrationFormProps) => {
 	return (
 		<div className="mx-auto max-w-2xl space-y-8 p-4">
+			<div>
+				<BackButton label="レース詳細へ戻る" href={`/races/${raceUid}`} />
+			</div>
+
 			<h1 className="text-xl font-semibold">出走馬登録</h1>
 
 			<ScrollableTable>

--- a/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.tsx
+++ b/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.tsx
@@ -1,6 +1,7 @@
 import BackButton from "@/components/presentational/BackButton";
 import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { Button } from "@/components/shadcn/ui/button";
+import { show as raceShow } from "@/routes/races";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceEntryRegistrationFormProps } from "./types";
 
@@ -17,7 +18,10 @@ const RaceEntryRegistrationForm = ({
 	return (
 		<div className="mx-auto max-w-2xl space-y-8 p-4">
 			<div>
-				<BackButton label="レース詳細へ戻る" href={`/races/${raceUid}`} />
+				<BackButton
+					label="レース詳細へ戻る"
+					href={raceShow.url({ race: raceUid })}
+				/>
 			</div>
 
 			<h1 className="text-xl font-semibold">出走馬登録</h1>

--- a/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/types.ts
+++ b/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/types.ts
@@ -5,6 +5,7 @@ export type RaceInfo = {
 };
 
 export type RaceEntryRegistrationFormProps = {
+	raceUid: string;
 	raceInfo: RaceInfo;
 	pastedText: string;
 	isSubmitting: boolean;

--- a/source/resources/js/features/raceInput/containers/RaceInputFormContainer/RaceInputFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceInput/containers/RaceInputFormContainer/RaceInputFormContainer.int.test.tsx
@@ -7,6 +7,13 @@ vi.mock("@inertiajs/react", () => ({
 	router: {
 		post: vi.fn(),
 	},
+	Link: ({
+		href,
+		children,
+	}: {
+		href: string;
+		children: React.ReactNode;
+	}) => <a href={href}>{children}</a>,
 }));
 
 import { router } from "@inertiajs/react";

--- a/source/resources/js/features/raceInput/presentational/RaceInputForm/RaceInputForm.unit.test.tsx
+++ b/source/resources/js/features/raceInput/presentational/RaceInputForm/RaceInputForm.unit.test.tsx
@@ -3,6 +3,16 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import RaceInputForm from "./index";
 
+vi.mock("@inertiajs/react", () => ({
+	Link: ({
+		href,
+		children,
+	}: {
+		href: string;
+		children: React.ReactNode;
+	}) => <a href={href}>{children}</a>,
+}));
+
 vi.mock("@/components/shadcn/ui/select", () => ({
 	Select: ({
 		value,
@@ -261,6 +271,27 @@ describe("RaceInputForm", () => {
 
 			// Assert
 			expect(screen.getByLabelText("レース名")).toHaveValue("天皇賞（春）");
+		});
+	});
+
+	describe("戻るボタン", () => {
+		it("「レース一覧へ戻る」テキストのリンクが表示される", () => {
+			// Act
+			render(<RaceInputForm {...baseProps} />);
+
+			// Assert
+			expect(
+				screen.getByRole("link", { name: "レース一覧へ戻る" }),
+			).toBeInTheDocument();
+		});
+
+		it("「レース一覧へ戻る」リンクの href が `/races` になっている", () => {
+			// Act
+			render(<RaceInputForm {...baseProps} />);
+
+			// Assert
+			const link = screen.getByRole("link", { name: "レース一覧へ戻る" });
+			expect(link).toHaveAttribute("href", "/races");
 		});
 	});
 });

--- a/source/resources/js/features/raceInput/presentational/RaceInputForm/index.tsx
+++ b/source/resources/js/features/raceInput/presentational/RaceInputForm/index.tsx
@@ -1,3 +1,4 @@
+import BackButton from "@/components/presentational/BackButton";
 import { Button } from "@/components/shadcn/ui/button";
 import { Input } from "@/components/shadcn/ui/input";
 import { Label } from "@/components/shadcn/ui/label";
@@ -69,6 +70,9 @@ const RaceInputForm = ({
 
 	return (
 		<div className="flex flex-col gap-6 p-4">
+			<div>
+				<BackButton label="レース一覧へ戻る" href="/races" />
+			</div>
 			<div>
 				<h1 className="text-xl font-semibold">レース情報入力</h1>
 				<p className="text-sm text-muted-foreground">

--- a/source/resources/js/features/raceInput/presentational/RaceInputForm/index.tsx
+++ b/source/resources/js/features/raceInput/presentational/RaceInputForm/index.tsx
@@ -9,6 +9,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/shadcn/ui/select";
+import { index as racesIndex } from "@/routes/races";
 import { useState } from "react";
 
 type Props = {
@@ -71,7 +72,7 @@ const RaceInputForm = ({
 	return (
 		<div className="flex flex-col gap-6 p-4">
 			<div>
-				<BackButton label="レース一覧へ戻る" href="/races" />
+				<BackButton label="レース一覧へ戻る" href={racesIndex.url()} />
 			</div>
 			<div>
 				<h1 className="text-xl font-semibold">レース情報入力</h1>

--- a/source/resources/js/features/raceResult/containers/RaceResultFormContainer/RaceResultFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceResult/containers/RaceResultFormContainer/RaceResultFormContainer.int.test.tsx
@@ -7,6 +7,13 @@ vi.mock("@inertiajs/react", () => ({
 	router: {
 		post: vi.fn(),
 	},
+	Link: ({
+		href,
+		children,
+	}: {
+		href: string;
+		children: React.ReactNode;
+	}) => <a href={href}>{children}</a>,
 }));
 
 import { router } from "@inertiajs/react";

--- a/source/resources/js/features/raceResult/containers/RaceResultFormContainer/index.tsx
+++ b/source/resources/js/features/raceResult/containers/RaceResultFormContainer/index.tsx
@@ -51,6 +51,7 @@ const RaceResultFormContainer = ({
 
 	return (
 		<RaceResultForm
+			raceUid={raceUid}
 			venueName={venueName}
 			raceDate={raceDate}
 			raceNumber={raceNumber}

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/RaceResultDetail.unit.test.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/RaceResultDetail.unit.test.tsx
@@ -90,4 +90,25 @@ describe("RaceResultDetail", () => {
 		const link = screen.getByRole("link", { name: "テスト馬A" });
 		expect(link).toHaveAttribute("href", "/horses/7");
 	});
+
+	describe("戻るボタン", () => {
+		it("「購入馬券一覧へ戻る」テキストのリンクが表示される", () => {
+			// Act
+			render(<RaceResultDetail {...baseProps} />);
+
+			// Assert
+			expect(
+				screen.getByRole("link", { name: "購入馬券一覧へ戻る" }),
+			).toBeInTheDocument();
+		});
+
+		it("「購入馬券一覧へ戻る」リンクの href が `/tickets` になっている", () => {
+			// Act
+			render(<RaceResultDetail {...baseProps} />);
+
+			// Assert
+			const link = screen.getByRole("link", { name: "購入馬券一覧へ戻る" });
+			expect(link).toHaveAttribute("href", "/tickets");
+		});
+	});
 });

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -2,6 +2,7 @@ import { Link } from "@inertiajs/react";
 import BackButton from "@/components/presentational/BackButton";
 import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { Button } from "@/components/shadcn/ui/button";
+import { index as ticketsIndex } from "@/routes/tickets";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceResultDetailProps } from "./types";
 import { formatHorseNumbers } from "./utils";
@@ -10,7 +11,7 @@ const RaceResultDetail = ({ race }: RaceResultDetailProps) => {
 	return (
 		<div className="flex flex-col gap-4 p-4">
 			<div>
-				<BackButton label="購入馬券一覧へ戻る" href="/tickets" />
+				<BackButton label="購入馬券一覧へ戻る" href={ticketsIndex.url()} />
 			</div>
 			<div className="flex items-center justify-between">
 				<div>

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@inertiajs/react";
+import BackButton from "@/components/presentational/BackButton";
 import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { Button } from "@/components/shadcn/ui/button";
 import { formatDateDisplay } from "@/utils/date";
@@ -8,6 +9,9 @@ import { formatHorseNumbers } from "./utils";
 const RaceResultDetail = ({ race }: RaceResultDetailProps) => {
 	return (
 		<div className="flex flex-col gap-4 p-4">
+			<div>
+				<BackButton label="購入馬券一覧へ戻る" href="/tickets" />
+			</div>
 			<div className="flex items-center justify-between">
 				<div>
 					<h1 className="text-xl font-semibold">レース結果</h1>

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/RaceResultForm.unit.test.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/RaceResultForm.unit.test.tsx
@@ -3,7 +3,18 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import RaceResultForm from "./index";
 
+vi.mock("@inertiajs/react", () => ({
+	Link: ({
+		href,
+		children,
+	}: {
+		href: string;
+		children: React.ReactNode;
+	}) => <a href={href}>{children}</a>,
+}));
+
 const baseProps = {
+	raceUid: "test-race-uid",
 	venueName: "東京",
 	raceDate: "2026-04-05",
 	raceNumber: 1,
@@ -200,6 +211,30 @@ describe("RaceResultForm", () => {
 
 			// Assert
 			expect(screen.getByRole("button", { name: "保存中..." })).toBeDisabled();
+		});
+	});
+
+	describe("戻るボタン", () => {
+		it("「レース結果へ戻る」テキストのリンクが表示される", () => {
+			// Act
+			render(<RaceResultForm {...baseProps} />);
+
+			// Assert
+			expect(
+				screen.getByRole("link", { name: "レース結果へ戻る" }),
+			).toBeInTheDocument();
+		});
+
+		it("「レース結果へ戻る」リンクの href が `/races/{raceUid}/result/edit` になっている", () => {
+			// Act
+			render(<RaceResultForm {...baseProps} />);
+
+			// Assert
+			const link = screen.getByRole("link", { name: "レース結果へ戻る" });
+			expect(link).toHaveAttribute(
+				"href",
+				"/races/test-race-uid/result/edit",
+			);
 		});
 	});
 });

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/index.stories.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/index.stories.tsx
@@ -12,6 +12,7 @@ type Story = StoryObj<typeof RaceResultForm>;
 
 const baseArgs: Pick<
 	RaceResultFormProps,
+	| "raceUid"
 	| "venueName"
 	| "raceDate"
 	| "raceNumber"
@@ -20,6 +21,7 @@ const baseArgs: Pick<
 	| "onSubmit"
 	| "isSubmitting"
 > = {
+	raceUid: "test-race-uid-123",
 	venueName: "東京",
 	raceDate: "2026-04-08",
 	raceNumber: 11,

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
@@ -1,6 +1,7 @@
 import AlertError from "@/components/presentational/AlertError";
 import BackButton from "@/components/presentational/BackButton";
 import { Button } from "@/components/shadcn/ui/button";
+import { edit as raceResultEdit } from "@/routes/races/result";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceResultFormProps } from "./types";
 
@@ -24,7 +25,7 @@ const RaceResultForm = ({
 			<div>
 				<BackButton
 					label="レース結果へ戻る"
-					href={`/races/${raceUid}/result/edit`}
+					href={raceResultEdit.url({ uid: raceUid })}
 				/>
 			</div>
 			<div>

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
@@ -1,9 +1,11 @@
-import { Button } from "@/components/shadcn/ui/button";
 import AlertError from "@/components/presentational/AlertError";
+import BackButton from "@/components/presentational/BackButton";
+import { Button } from "@/components/shadcn/ui/button";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceResultFormProps } from "./types";
 
 const RaceResultForm = ({
+	raceUid,
 	venueName,
 	raceDate,
 	raceNumber,
@@ -19,6 +21,12 @@ const RaceResultForm = ({
 }: RaceResultFormProps) => {
 	return (
 		<div className="flex flex-col gap-6 p-4">
+			<div>
+				<BackButton
+					label="レース結果へ戻る"
+					href={`/races/${raceUid}/result/edit`}
+				/>
+			</div>
 			<div>
 				<h1 className="text-xl font-semibold">レース結果入力</h1>
 				<p className="text-sm text-muted-foreground">

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/types.ts
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/types.ts
@@ -1,4 +1,5 @@
 export type RaceResultFormProps = {
+	raceUid: string;
 	venueName: string;
 	raceDate: string;
 	raceNumber: number;

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketPurchaseForm.unit.test.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/TicketPurchaseForm.unit.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
 import TicketPurchaseForm, {
 	TICKET_TYPES,
 	BUY_TYPE_MAP,
@@ -355,6 +356,34 @@ describe("TicketPurchaseForm", () => {
 			// Assert
 			expect(screen.queryByText("軸の頭数")).not.toBeInTheDocument();
 			expect(screen.queryByText("流し方向")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("戻るボタン", () => {
+		it("「戻る」ボタンが表示される", () => {
+			// Act
+			render(<TicketPurchaseForm {...baseProps} />);
+
+			// Assert
+			expect(
+				screen.getByRole("button", { name: "戻る" }),
+			).toBeInTheDocument();
+		});
+
+		it("「戻る」ボタンをクリックすると window.history.back が呼ばれる", async () => {
+			// Arrange
+			const backSpy = vi
+				.spyOn(window.history, "back")
+				.mockImplementation(() => {});
+			const user = userEvent.setup();
+
+			// Act
+			render(<TicketPurchaseForm {...baseProps} />);
+			await user.click(screen.getByRole("button", { name: "戻る" }));
+
+			// Assert
+			expect(backSpy).toHaveBeenCalledTimes(1);
+			backSpy.mockRestore();
 		});
 	});
 });

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/index.tsx
@@ -1,3 +1,4 @@
+import BackButton from "@/components/presentational/BackButton";
 import { Button } from "@/components/shadcn/ui/button";
 import { Input } from "@/components/shadcn/ui/input";
 import { HorseSelectionSection } from "./HorseSelectionSection";
@@ -35,6 +36,10 @@ const TicketPurchaseForm = ({
 }: TicketPurchaseFormProps) => {
 	return (
 		<div className="mx-auto max-w-2xl space-y-8 p-4">
+			<div>
+				<BackButton label="戻る" />
+			</div>
+
 			<RaceInfoSection
 				selectedVenue={selectedVenue}
 				selectedRaceDate={selectedRaceDate}

--- a/source/resources/js/pages/races/result/create.int.test.tsx
+++ b/source/resources/js/pages/races/result/create.int.test.tsx
@@ -17,6 +17,13 @@ vi.mock("@inertiajs/react", () => ({
 	router: {
 		post: vi.fn(),
 	},
+	Link: ({
+		href,
+		children,
+	}: {
+		href: string;
+		children: React.ReactNode;
+	}) => <a href={href}>{children}</a>,
 }));
 
 describe("RaceResultCreate ページ", () => {


### PR DESCRIPTION
## やったこと

- 共通プレゼンコンポーネント `BackButton` を新設（`resources/js/components/presentational/BackButton/`）
  - `href` 指定時は Inertia `<Link>` でページ遷移、未指定時はブラウザ `history.back()` を呼ぶ
  - `lucide-react` の `ArrowLeft` アイコン付き
- 下記6画面に BackButton を追加:
  - レース結果入力（`/races/{uid}/result/new`）→ レース結果へ戻る
  - レース結果確認・編集（`/races/{uid}/result/edit`）→ 購入馬券一覧へ戻る
  - 馬券登録（`/tickets/new`）→ 戻る（ブラウザback）
  - レース情報入力（`/races/new`）→ レース一覧へ戻る
  - 出走馬登録（`/races/{uid}/entries/new`）→ レース詳細へ戻る
  - 競走馬詳細（`/horses/{horse}`）→ 戻る（ブラウザback）
- BackButton の単体テストを追加（href あり／なし）
- 各画面の既存テストに戻るボタンの表示・リンク先のテストを追記
- 統合テストの `@inertiajs/react` モックに `Link` を追加（BackButton 組み込みによる失敗を解消）
- `RaceResultFormContainer` / `RaceEntryRegistrationFormContainer` に `raceUid` prop の受け渡しを追加

## 結果

（スクリーンショット・動画は動作確認後に追加してください）

## 動作確認済み

- [ ] レース結果入力画面（`/races/{uid}/result/new`）で「レース結果へ戻る」ボタンが `/races/{uid}/result/edit` に遷移する
- [ ] レース結果確認・編集画面（`/races/{uid}/result/edit`）で「購入馬券一覧へ戻る」ボタンが `/tickets` に遷移する
- [ ] 馬券登録画面（`/tickets/new`）で「戻る」ボタンがブラウザ履歴を1つ戻る
- [ ] レース情報入力画面（`/races/new`）で「レース一覧へ戻る」ボタンが `/races` に遷移する
- [ ] 出走馬登録画面（`/races/{uid}/entries/new`）で「レース詳細へ戻る」ボタンが `/races/{uid}` に遷移する
- [ ] 競走馬詳細画面（`/horses/{horse}`）で「戻る」ボタンがブラウザ履歴を1つ戻る