### PR TITLE
[minor] 競走馬メモ削除機能の追加

### DIFF
--- a/docs/specs/api-list.md
+++ b/docs/specs/api-list.md
@@ -10,3 +10,4 @@
 | GET | `/api/horses/{horse}/notes` | 認証ユーザーが所有する当該馬の全メモ（レース紐づきあり・なし含む）を取得する。 | 必要 |
 | POST | `/api/horses/{horse}/notes` | 競走馬に対するメモを作成する（race_id は任意、null可）。 | 必要 |
 | PUT | `/api/horse-notes/{note}` | メモ本文を更新する（content のみ更新可能）。 | 必要 |
+| DELETE | `/api/horse-notes/{note}` | メモを物理削除する（自分のメモのみ削除可能、他ユーザー所有のメモは 403）。 | 必要 |

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -349,6 +349,24 @@ paths:
           $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/ValidationError"
+    delete:
+      tags: [horse-notes]
+      summary: メモを削除
+      description: |
+        指定メモを物理削除する。soft delete は行わない。
+        他ユーザー所有のメモに対するリクエストは 403 を返す。
+      operationId: deleteHorseNote
+      security:
+        - sessionAuth: []
+      responses:
+        "204":
+          description: No Content
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
 components:
   parameters:

--- a/source/app/Http/Controllers/HorseNoteController.php
+++ b/source/app/Http/Controllers/HorseNoteController.php
@@ -6,11 +6,13 @@ use App\Http\Requests\HorseNote\StoreHorseNoteRequest;
 use App\Http\Requests\HorseNote\UpdateHorseNoteRequest;
 use App\Models\Horse;
 use App\Models\HorseNote;
+use App\UseCases\HorseNote\DeleteAction;
 use App\UseCases\HorseNote\IndexAction;
 use App\UseCases\HorseNote\StoreAction;
 use App\UseCases\HorseNote\UpdateAction;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 class HorseNoteController extends Controller
 {
@@ -42,5 +44,12 @@ class HorseNoteController extends Controller
         );
 
         return response()->json(['data' => $data]);
+    }
+
+    public function destroy(HorseNote $note, Request $request, DeleteAction $action): Response
+    {
+        $action->execute($note, $request->user());
+
+        return response()->noContent();
     }
 }

--- a/source/app/UseCases/HorseNote/DeleteAction.php
+++ b/source/app/UseCases/HorseNote/DeleteAction.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\UseCases\HorseNote;
+
+use App\Models\HorseNote;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+
+/**
+ * 認証ユーザー所有の競走馬メモを物理削除する。他人のメモは AuthorizationException。
+ */
+class DeleteAction
+{
+    /**
+     * @throws AuthorizationException
+     */
+    public function execute(HorseNote $note, User $user): void
+    {
+        if ((int) $note->user_id !== (int) $user->id) {
+            throw new AuthorizationException('他のユーザーのメモは削除できません。');
+        }
+
+        $note->delete();
+    }
+}

--- a/source/resources/js/features/horseNote/containers/HorseNotesListContainer/HorseNotesListContainer.int.test.tsx
+++ b/source/resources/js/features/horseNote/containers/HorseNotesListContainer/HorseNotesListContainer.int.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import HorseNotesListContainer from "./index";
 
 vi.mock("@inertiajs/react", () => ({
@@ -10,6 +10,10 @@ vi.mock("@inertiajs/react", () => ({
 }));
 
 describe("HorseNotesListContainer", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("ハッピーパス: メモ追加ボタンを押すとモーダルが create モードで開く", async () => {
 		// Arrange
 		const user = userEvent.setup();
@@ -39,5 +43,43 @@ describe("HorseNotesListContainer", () => {
 			screen.getByRole("heading", { name: "メモを追加" }),
 		).toBeInTheDocument();
 		expect(screen.getByText("ディープスター")).toBeInTheDocument();
+	});
+
+	it("ハッピーパス: 削除ボタン押下→確認ダイアログ表示→削除するでメモが一覧から消える", async () => {
+		// Arrange
+		const user = userEvent.setup();
+		vi.spyOn(global, "fetch").mockResolvedValue(
+			new Response(null, { status: 204 }),
+		);
+		render(
+			<HorseNotesListContainer
+				horseId={100}
+				horseName="ディープスター"
+				initialNotes={[
+					{
+						id: 10,
+						content: "削除対象メモ",
+						race: null,
+						created_at: "2026-04-25T10:00:00Z",
+						updated_at: "2026-04-25T10:00:00Z",
+					},
+				]}
+				raceOptions={[]}
+			/>,
+		);
+
+		// Act
+		await user.click(screen.getByRole("button", { name: "削除" }));
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: "削除する" }));
+
+		// Assert
+		await waitFor(() => {
+			expect(screen.queryByText("削除対象メモ")).not.toBeInTheDocument();
+		});
+		const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock
+			.calls[0] as [string, RequestInit];
+		expect(url).toBe("/api/horse-notes/10");
+		expect(init.method).toBe("DELETE");
 	});
 });

--- a/source/resources/js/features/horseNote/containers/HorseNotesListContainer/index.tsx
+++ b/source/resources/js/features/horseNote/containers/HorseNotesListContainer/index.tsx
@@ -29,7 +29,7 @@ type EditTarget = {
 
 type DeleteTarget = {
 	id: number;
-	contentPreview: string;
+	content: string;
 };
 
 /**
@@ -100,7 +100,7 @@ const HorseNotesListContainer = ({
 		}
 		setDeleteTarget({
 			id: target.id,
-			contentPreview: target.content,
+			content: target.content,
 		});
 		setDeleteErrorMessage(null);
 		setDeleteOpen(true);
@@ -129,6 +129,14 @@ const HorseNotesListContainer = ({
 			setDeleteOpen(false);
 			setDeleteTarget(null);
 		} catch (e) {
+			// 別タブ等で先に削除済みのケース。サーバ実態に合わせ一覧からも除去して案内する。
+			if (e instanceof HorseNoteRequestError && e.status === 404) {
+				setNotes((current) => current.filter((n) => n.id !== deleteTarget.id));
+				setDeleteOpen(false);
+				setDeleteTarget(null);
+				toast.info("対象のメモは既に削除されています。");
+				return;
+			}
 			const message =
 				e instanceof HorseNoteRequestError
 					? e.message
@@ -196,7 +204,7 @@ const HorseNotesListContainer = ({
 			/>
 			<HorseNoteDeleteConfirmDialog
 				open={deleteOpen}
-				noteContentPreview={deleteTarget?.contentPreview ?? ""}
+				noteContent={deleteTarget?.content ?? ""}
 				submitting={deleteSubmitting}
 				errorMessage={deleteErrorMessage}
 				onOpenChange={handleDeleteOpenChange}

--- a/source/resources/js/features/horseNote/containers/HorseNotesListContainer/index.tsx
+++ b/source/resources/js/features/horseNote/containers/HorseNotesListContainer/index.tsx
@@ -1,12 +1,18 @@
 import HorseNoteModalContainer, {
 	type HorseNoteModalRaceContext,
 } from "@/features/horseNote/containers/HorseNoteModalContainer";
+import HorseNoteDeleteConfirmDialog from "@/features/horseNote/presentational/HorseNoteDeleteConfirmDialog";
 import type { HorseNoteRaceOption } from "@/features/horseNote/presentational/HorseNoteModal/types";
 import HorseNotesList from "@/features/horseNote/presentational/HorseNotesList";
 import type { HorseNoteListItem } from "@/features/horseNote/presentational/HorseNotesList/types";
+import {
+	HorseNoteRequestError,
+	deleteNote,
+} from "@/features/horseNote/requests/horseNotes";
 import type { HorseNote } from "@/features/horseNote/types/horseNote";
 import { formatDateDisplay } from "@/utils/date";
 import { useMemo, useState } from "react";
+import { toast } from "sonner";
 
 type Props = {
 	horseId: number;
@@ -19,6 +25,11 @@ type EditTarget = {
 	id: number;
 	content: string;
 	raceContext: HorseNoteModalRaceContext;
+};
+
+type DeleteTarget = {
+	id: number;
+	contentPreview: string;
 };
 
 /**
@@ -36,6 +47,12 @@ const HorseNotesListContainer = ({
 	const [open, setOpen] = useState<boolean>(false);
 	const [mode, setMode] = useState<"create" | "edit">("create");
 	const [editTarget, setEditTarget] = useState<EditTarget | null>(null);
+	const [deleteOpen, setDeleteOpen] = useState<boolean>(false);
+	const [deleteSubmitting, setDeleteSubmitting] = useState<boolean>(false);
+	const [deleteErrorMessage, setDeleteErrorMessage] = useState<string | null>(
+		null,
+	);
+	const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
 
 	const createRaceContext = useMemo<HorseNoteModalRaceContext>(() => {
 		if (raceOptions.length === 0) {
@@ -76,6 +93,53 @@ const HorseNotesListContainer = ({
 		setOpen(false);
 	};
 
+	const handleDeleteClick = (noteId: number) => {
+		const target = notes.find((n) => n.id === noteId);
+		if (target == null) {
+			return;
+		}
+		setDeleteTarget({
+			id: target.id,
+			contentPreview: target.content,
+		});
+		setDeleteErrorMessage(null);
+		setDeleteOpen(true);
+	};
+
+	const handleDeleteOpenChange = (next: boolean) => {
+		if (next) {
+			return;
+		}
+		if (deleteSubmitting) {
+			return;
+		}
+		setDeleteOpen(false);
+		setDeleteErrorMessage(null);
+	};
+
+	const handleDeleteConfirm = async () => {
+		if (deleteTarget == null) {
+			return;
+		}
+		setDeleteSubmitting(true);
+		setDeleteErrorMessage(null);
+		try {
+			await deleteNote(deleteTarget.id);
+			setNotes((current) => current.filter((n) => n.id !== deleteTarget.id));
+			setDeleteOpen(false);
+			setDeleteTarget(null);
+		} catch (e) {
+			const message =
+				e instanceof HorseNoteRequestError
+					? e.message
+					: "メモの削除に失敗しました";
+			setDeleteErrorMessage(message);
+			toast.error(message);
+		} finally {
+			setDeleteSubmitting(false);
+		}
+	};
+
 	const handleSuccess = (note: HorseNote) => {
 		const item: HorseNoteListItem = {
 			id: note.id,
@@ -112,6 +176,7 @@ const HorseNotesListContainer = ({
 				notes={notes}
 				onAddClick={handleAddClick}
 				onEditClick={handleEditClick}
+				onDeleteClick={handleDeleteClick}
 			/>
 			<HorseNoteModalContainer
 				open={open}
@@ -128,6 +193,14 @@ const HorseNotesListContainer = ({
 				raceContext={modalRaceContext}
 				onClose={handleClose}
 				onSuccess={handleSuccess}
+			/>
+			<HorseNoteDeleteConfirmDialog
+				open={deleteOpen}
+				noteContentPreview={deleteTarget?.contentPreview ?? ""}
+				submitting={deleteSubmitting}
+				errorMessage={deleteErrorMessage}
+				onOpenChange={handleDeleteOpenChange}
+				onConfirm={handleDeleteConfirm}
 			/>
 		</>
 	);

--- a/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.stories.tsx
+++ b/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof HorseNoteDeleteConfirmDialog>;
 export const Default: Story = {
 	name: "通常状態",
 	args: {
-		noteContentPreview:
+		noteContent:
 			"次この条件だったら買いたい。芝1600mの稍重がベスト条件。",
 		submitting: false,
 		errorMessage: null,
@@ -27,7 +27,7 @@ export const Default: Story = {
 export const Submitting: Story = {
 	name: "削除処理中（ボタンdisabled）",
 	args: {
-		noteContentPreview:
+		noteContent:
 			"次この条件だったら買いたい。芝1600mの稍重がベスト条件。",
 		submitting: true,
 		errorMessage: null,
@@ -37,7 +37,7 @@ export const Submitting: Story = {
 export const WithError: Story = {
 	name: "削除失敗（エラー表示）",
 	args: {
-		noteContentPreview:
+		noteContent:
 			"次この条件だったら買いたい。芝1600mの稍重がベスト条件。",
 		submitting: false,
 		errorMessage: "メモの削除に失敗しました。時間をおいて再度お試しください。",
@@ -45,10 +45,10 @@ export const WithError: Story = {
 };
 
 export const LongContent: Story = {
-	name: "メモ本文が長い場合（プレビュー切り詰め後）",
+	name: "メモ本文が長い場合（最大高さで縦スクロール）",
 	args: {
-		noteContentPreview:
-			"前走は外枠で出遅れ気味。次は内枠なら本命視。鞍上継続騎乗で前進期待。馬体重は前走比でマイナス4kg程度なら理想。直近の追い切り内容も上々で、状態面の不安は少ない…",
+		noteContent:
+			"前走は外枠で出遅れ気味。次は内枠なら本命視。鞍上継続騎乗で前進期待。馬体重は前走比でマイナス4kg程度なら理想。直近の追い切り内容も上々で、状態面の不安は少ない。展開的には先行馬有利のトラックバイアスが想定されるため、好位差し脚質との相性も悪くない。距離適性は1600〜2000mで問題なし。馬場は良〜稍重が好走条件で、重・不良は割引が必要。鞍上騎手の今開催コース成績も上昇基調で、信頼感は高い。",
 		submitting: false,
 		errorMessage: null,
 	},
@@ -60,7 +60,7 @@ export const Mobile: Story = {
 		viewport: { value: "mobile1", isRotated: false },
 	},
 	args: {
-		noteContentPreview:
+		noteContent:
 			"次この条件だったら買いたい。芝1600mの稍重がベスト条件。",
 		submitting: false,
 		errorMessage: null,

--- a/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.stories.tsx
+++ b/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import HorseNoteDeleteConfirmDialog from ".";
+
+const meta: Meta<typeof HorseNoteDeleteConfirmDialog> = {
+	title: "features/horseNote/presentational/HorseNoteDeleteConfirmDialog",
+	component: HorseNoteDeleteConfirmDialog,
+	args: {
+		open: true,
+		onOpenChange: () => {},
+		onConfirm: () => {},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof HorseNoteDeleteConfirmDialog>;
+
+export const Default: Story = {
+	name: "通常状態",
+	args: {
+		noteContentPreview:
+			"次この条件だったら買いたい。芝1600mの稍重がベスト条件。",
+		submitting: false,
+		errorMessage: null,
+	},
+};
+
+export const Submitting: Story = {
+	name: "削除処理中（ボタンdisabled）",
+	args: {
+		noteContentPreview:
+			"次この条件だったら買いたい。芝1600mの稍重がベスト条件。",
+		submitting: true,
+		errorMessage: null,
+	},
+};
+
+export const WithError: Story = {
+	name: "削除失敗（エラー表示）",
+	args: {
+		noteContentPreview:
+			"次この条件だったら買いたい。芝1600mの稍重がベスト条件。",
+		submitting: false,
+		errorMessage: "メモの削除に失敗しました。時間をおいて再度お試しください。",
+	},
+};
+
+export const LongContent: Story = {
+	name: "メモ本文が長い場合（プレビュー切り詰め後）",
+	args: {
+		noteContentPreview:
+			"前走は外枠で出遅れ気味。次は内枠なら本命視。鞍上継続騎乗で前進期待。馬体重は前走比でマイナス4kg程度なら理想。直近の追い切り内容も上々で、状態面の不安は少ない…",
+		submitting: false,
+		errorMessage: null,
+	},
+};
+
+export const Mobile: Story = {
+	name: "モバイル表示",
+	globals: {
+		viewport: { value: "mobile1", isRotated: false },
+	},
+	args: {
+		noteContentPreview:
+			"次この条件だったら買いたい。芝1600mの稍重がベスト条件。",
+		submitting: false,
+		errorMessage: null,
+	},
+};

--- a/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.tsx
+++ b/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.tsx
@@ -13,7 +13,7 @@ import type { HorseNoteDeleteConfirmDialogProps } from "./types";
 
 const HorseNoteDeleteConfirmDialog = ({
 	open,
-	noteContentPreview,
+	noteContent,
 	submitting,
 	errorMessage,
 	onOpenChange,
@@ -30,9 +30,9 @@ const HorseNoteDeleteConfirmDialog = ({
 				</DialogHeader>
 
 				<div className="flex flex-col gap-4">
-					<div className="rounded-md border bg-muted/40 p-3">
+					<div className="max-h-48 overflow-y-auto rounded-md border bg-muted/40 p-3">
 						<p className="whitespace-pre-wrap break-words text-sm text-muted-foreground">
-							{noteContentPreview}
+							{noteContent}
 						</p>
 					</div>
 

--- a/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.tsx
+++ b/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.tsx
@@ -1,0 +1,65 @@
+import AlertError from "@/components/presentational/AlertError";
+import { Button } from "@/components/shadcn/ui/button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/shadcn/ui/dialog";
+import type { HorseNoteDeleteConfirmDialogProps } from "./types";
+
+const HorseNoteDeleteConfirmDialog = ({
+	open,
+	noteContentPreview,
+	submitting,
+	errorMessage,
+	onOpenChange,
+	onConfirm,
+}: HorseNoteDeleteConfirmDialogProps) => {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>メモを削除</DialogTitle>
+					<DialogDescription>
+						このメモを削除します。この操作は取り消せません。
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="flex flex-col gap-4">
+					<div className="rounded-md border bg-muted/40 p-3">
+						<p className="whitespace-pre-wrap break-words text-sm text-muted-foreground">
+							{noteContentPreview}
+						</p>
+					</div>
+
+					{errorMessage !== null && (
+						<AlertError errors={[errorMessage]} title="エラー" />
+					)}
+				</div>
+
+				<DialogFooter>
+					<DialogClose asChild>
+						<Button variant="outline" disabled={submitting}>
+							キャンセル
+						</Button>
+					</DialogClose>
+					<Button
+						variant="destructive"
+						onClick={onConfirm}
+						disabled={submitting}
+					>
+						削除する
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+export default HorseNoteDeleteConfirmDialog;
+
+export type { HorseNoteDeleteConfirmDialogProps } from "./types";

--- a/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.unit.test.tsx
+++ b/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.unit.test.tsx
@@ -6,7 +6,7 @@ import type { HorseNoteDeleteConfirmDialogProps } from "./types";
 
 const baseProps: HorseNoteDeleteConfirmDialogProps = {
 	open: true,
-	noteContentPreview: "削除対象メモの本文プレビュー",
+	noteContent: "削除対象メモの本文",
 	submitting: false,
 	errorMessage: null,
 	onOpenChange: () => {},
@@ -33,17 +33,17 @@ describe("HorseNoteDeleteConfirmDialog", () => {
 	});
 
 	describe("コンテンツ表示", () => {
-		it("noteContentPreview に指定したメモ本文プレビューが表示される", () => {
+		it("noteContent に指定したメモ本文が表示される", () => {
 			// Act
 			render(
 				<HorseNoteDeleteConfirmDialog
 					{...baseProps}
-					noteContentPreview="プレビュー本文テキスト"
+					noteContent="表示用の本文テキスト"
 				/>,
 			);
 
 			// Assert
-			expect(screen.getByText("プレビュー本文テキスト")).toBeInTheDocument();
+			expect(screen.getByText("表示用の本文テキスト")).toBeInTheDocument();
 		});
 	});
 

--- a/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.unit.test.tsx
+++ b/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.unit.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import HorseNoteDeleteConfirmDialog from "./index";
+import type { HorseNoteDeleteConfirmDialogProps } from "./types";
+
+const baseProps: HorseNoteDeleteConfirmDialogProps = {
+	open: true,
+	noteContentPreview: "削除対象メモの本文プレビュー",
+	submitting: false,
+	errorMessage: null,
+	onOpenChange: () => {},
+	onConfirm: () => {},
+};
+
+describe("HorseNoteDeleteConfirmDialog", () => {
+	describe("表示制御", () => {
+		it("open=true の場合、ダイアログが表示される", () => {
+			// Act
+			render(<HorseNoteDeleteConfirmDialog {...baseProps} open={true} />);
+
+			// Assert
+			expect(screen.getByRole("dialog")).toBeInTheDocument();
+		});
+
+		it("open=false の場合、ダイアログが表示されない", () => {
+			// Act
+			render(<HorseNoteDeleteConfirmDialog {...baseProps} open={false} />);
+
+			// Assert
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("コンテンツ表示", () => {
+		it("noteContentPreview に指定したメモ本文プレビューが表示される", () => {
+			// Act
+			render(
+				<HorseNoteDeleteConfirmDialog
+					{...baseProps}
+					noteContentPreview="プレビュー本文テキスト"
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByText("プレビュー本文テキスト")).toBeInTheDocument();
+		});
+	});
+
+	describe("操作", () => {
+		it("「削除する」ボタンを押すと onConfirm が呼ばれる", async () => {
+			// Arrange
+			const onConfirm = vi.fn();
+			const user = userEvent.setup();
+
+			// Act
+			render(
+				<HorseNoteDeleteConfirmDialog
+					{...baseProps}
+					onConfirm={onConfirm}
+				/>,
+			);
+			await user.click(screen.getByRole("button", { name: "削除する" }));
+
+			// Assert
+			expect(onConfirm).toHaveBeenCalledTimes(1);
+		});
+
+		it("「キャンセル」ボタンを押すと onOpenChange が false で呼ばれる", async () => {
+			// Arrange
+			const onOpenChange = vi.fn();
+			const user = userEvent.setup();
+
+			// Act
+			render(
+				<HorseNoteDeleteConfirmDialog
+					{...baseProps}
+					onOpenChange={onOpenChange}
+				/>,
+			);
+			await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+			// Assert
+			expect(onOpenChange).toHaveBeenCalledWith(false);
+		});
+	});
+
+	describe("送信ボタンの状態", () => {
+		it("submitting=true の場合、「削除する」ボタンが無効化される", () => {
+			// Act
+			render(
+				<HorseNoteDeleteConfirmDialog {...baseProps} submitting={true} />,
+			);
+
+			// Assert
+			expect(
+				screen.getByRole("button", { name: "削除する" }),
+			).toBeDisabled();
+		});
+	});
+});

--- a/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.unit.test.tsx
+++ b/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/index.unit.test.tsx
@@ -98,4 +98,21 @@ describe("HorseNoteDeleteConfirmDialog", () => {
 			).toBeDisabled();
 		});
 	});
+
+	describe("エラー表示", () => {
+		it("errorMessage が指定されている場合、エラーメッセージが表示される", () => {
+			// Act
+			render(
+				<HorseNoteDeleteConfirmDialog
+					{...baseProps}
+					errorMessage="メモの削除に失敗しました"
+				/>,
+			);
+
+			// Assert
+			expect(
+				screen.getByText("メモの削除に失敗しました"),
+			).toBeInTheDocument();
+		});
+	});
 });

--- a/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/types.ts
+++ b/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/types.ts
@@ -1,6 +1,6 @@
 export type HorseNoteDeleteConfirmDialogProps = {
 	open: boolean;
-	noteContentPreview: string;
+	noteContent: string;
 	submitting: boolean;
 	errorMessage: string | null;
 	onOpenChange: (open: boolean) => void;

--- a/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/types.ts
+++ b/source/resources/js/features/horseNote/presentational/HorseNoteDeleteConfirmDialog/types.ts
@@ -1,0 +1,8 @@
+export type HorseNoteDeleteConfirmDialogProps = {
+	open: boolean;
+	noteContentPreview: string;
+	submitting: boolean;
+	errorMessage: string | null;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => void;
+};

--- a/source/resources/js/features/horseNote/presentational/HorseNotesList/index.stories.tsx
+++ b/source/resources/js/features/horseNote/presentational/HorseNotesList/index.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof HorseNotesList> = {
 	args: {
 		onAddClick: () => {},
 		onEditClick: () => {},
+		onDeleteClick: () => {},
 	},
 };
 

--- a/source/resources/js/features/horseNote/presentational/HorseNotesList/index.tsx
+++ b/source/resources/js/features/horseNote/presentational/HorseNotesList/index.tsx
@@ -7,6 +7,7 @@ const HorseNotesList = ({
 	notes,
 	onAddClick,
 	onEditClick,
+	onDeleteClick,
 }: HorseNotesListProps) => {
 	return (
 		<div className="flex flex-col gap-3">
@@ -51,13 +52,21 @@ const HorseNotesList = ({
 								</span>
 							</div>
 							<p className="whitespace-pre-wrap text-sm">{note.content}</p>
-							<div className="flex justify-end">
+							<div className="flex justify-end gap-1">
 								<Button
 									variant="ghost"
 									size="sm"
 									onClick={() => onEditClick(note.id)}
 								>
 									編集
+								</Button>
+								<Button
+									variant="ghost"
+									size="sm"
+									className="text-destructive hover:text-destructive"
+									onClick={() => onDeleteClick(note.id)}
+								>
+									削除
 								</Button>
 							</div>
 						</li>

--- a/source/resources/js/features/horseNote/presentational/HorseNotesList/index.unit.test.tsx
+++ b/source/resources/js/features/horseNote/presentational/HorseNotesList/index.unit.test.tsx
@@ -39,6 +39,7 @@ describe("HorseNotesList", () => {
 					notes={[raceLinkedNote, horseLinkedNote]}
 					onAddClick={() => {}}
 					onEditClick={() => {}}
+					onDeleteClick={() => {}}
 				/>,
 			);
 
@@ -56,6 +57,7 @@ describe("HorseNotesList", () => {
 					notes={[]}
 					onAddClick={() => {}}
 					onEditClick={() => {}}
+					onDeleteClick={() => {}}
 				/>,
 			);
 
@@ -72,6 +74,7 @@ describe("HorseNotesList", () => {
 					notes={[]}
 					onAddClick={() => {}}
 					onEditClick={() => {}}
+					onDeleteClick={() => {}}
 				/>,
 			);
 
@@ -92,6 +95,7 @@ describe("HorseNotesList", () => {
 					notes={[]}
 					onAddClick={onAddClick}
 					onEditClick={() => {}}
+					onDeleteClick={() => {}}
 				/>,
 			);
 			await user.click(screen.getByRole("button", { name: "メモを追加" }));
@@ -113,12 +117,35 @@ describe("HorseNotesList", () => {
 					notes={[raceLinkedNote]}
 					onAddClick={() => {}}
 					onEditClick={onEditClick}
+					onDeleteClick={() => {}}
 				/>,
 			);
 			await user.click(screen.getByRole("button", { name: "編集" }));
 
 			// Assert
 			expect(onEditClick).toHaveBeenCalledWith(1);
+		});
+	});
+
+	describe("削除操作", () => {
+		it("削除ボタンを押すと onDeleteClick がメモ ID で呼ばれる", async () => {
+			// Arrange
+			const onDeleteClick = vi.fn();
+			const user = userEvent.setup();
+
+			// Act
+			render(
+				<HorseNotesList
+					notes={[raceLinkedNote]}
+					onAddClick={() => {}}
+					onEditClick={() => {}}
+					onDeleteClick={onDeleteClick}
+				/>,
+			);
+			await user.click(screen.getByRole("button", { name: "削除" }));
+
+			// Assert
+			expect(onDeleteClick).toHaveBeenCalledWith(1);
 		});
 	});
 
@@ -130,6 +157,7 @@ describe("HorseNotesList", () => {
 					notes={[raceLinkedNote]}
 					onAddClick={() => {}}
 					onEditClick={() => {}}
+					onDeleteClick={() => {}}
 				/>,
 			);
 
@@ -148,6 +176,7 @@ describe("HorseNotesList", () => {
 					notes={[horseLinkedNote]}
 					onAddClick={() => {}}
 					onEditClick={() => {}}
+					onDeleteClick={() => {}}
 				/>,
 			);
 

--- a/source/resources/js/features/horseNote/presentational/HorseNotesList/types.ts
+++ b/source/resources/js/features/horseNote/presentational/HorseNotesList/types.ts
@@ -13,4 +13,5 @@ export type HorseNotesListProps = {
 	notes: HorseNoteListItem[];
 	onAddClick: () => void;
 	onEditClick: (noteId: number) => void;
+	onDeleteClick: (noteId: number) => void;
 };

--- a/source/resources/js/features/horseNote/requests/horseNotes.ts
+++ b/source/resources/js/features/horseNote/requests/horseNotes.ts
@@ -108,3 +108,18 @@ export const updateNote = async (
 	const json = (await response.json()) as ApiResponse;
 	return json.data;
 };
+
+/**
+ * 既存メモを削除する。成功時は 204 No Content を返すためレスポンスボディは扱わない。
+ */
+export const deleteNote = async (noteId: number): Promise<void> => {
+	const response = await fetch(`/api/horse-notes/${noteId}`, {
+		method: "DELETE",
+		headers: buildJsonHeaders(),
+		credentials: "same-origin",
+	});
+	if (!response.ok) {
+		const message = await extractErrorMessage(response);
+		throw new HorseNoteRequestError(message, response.status);
+	}
+};

--- a/source/resources/js/features/horseNote/requests/horseNotes.ts
+++ b/source/resources/js/features/horseNote/requests/horseNotes.ts
@@ -31,7 +31,16 @@ export class HorseNoteRequestError extends Error {
 	}
 }
 
-const extractErrorMessage = async (response: Response): Promise<string> => {
+/**
+ * 対象が存在しない（404）ときに表示するメッセージ。
+ * 別タブ等で先に削除されたメモへ更新・削除を行ったケースを想定する。
+ */
+const NOTE_NOT_FOUND_MESSAGE =
+	"対象のメモが見つかりません。すでに削除された可能性があります。";
+
+export const extractErrorMessage = async (
+	response: Response,
+): Promise<string> => {
 	if (response.status === 422) {
 		try {
 			const json = (await response.json()) as ValidationErrorBody;
@@ -45,6 +54,9 @@ const extractErrorMessage = async (response: Response): Promise<string> => {
 		} catch (_e) {
 			// JSON parse 失敗時はフォールバック
 		}
+	}
+	if (response.status === 404) {
+		return NOTE_NOT_FOUND_MESSAGE;
 	}
 	return `Request failed: ${response.status}`;
 };

--- a/source/resources/js/features/horseNote/requests/horseNotes.unit.test.ts
+++ b/source/resources/js/features/horseNote/requests/horseNotes.unit.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { extractErrorMessage } from "./horseNotes";
+
+describe("extractErrorMessage", () => {
+	it("404 の場合は対象が存在しない旨の固定メッセージを返す", async () => {
+		// Arrange
+		const response = new Response(null, { status: 404 });
+
+		// Act
+		const result = await extractErrorMessage(response);
+
+		// Assert
+		expect(result).toBe(
+			"対象のメモが見つかりません。すでに削除された可能性があります。",
+		);
+	});
+
+	it("422 でバリデーションエラーがある場合は errors.content[0] を返す", async () => {
+		// Arrange
+		const response = new Response(
+			JSON.stringify({
+				message: "The given data was invalid.",
+				errors: { content: ["メモは1000文字以内で入力してください。"] },
+			}),
+			{ status: 422, headers: { "Content-Type": "application/json" } },
+		);
+
+		// Act
+		const result = await extractErrorMessage(response);
+
+		// Assert
+		expect(result).toBe("メモは1000文字以内で入力してください。");
+	});
+
+	it("422 で errors.content がない場合は message を返す", async () => {
+		// Arrange
+		const response = new Response(
+			JSON.stringify({ message: "Validation failed" }),
+			{ status: 422, headers: { "Content-Type": "application/json" } },
+		);
+
+		// Act
+		const result = await extractErrorMessage(response);
+
+		// Assert
+		expect(result).toBe("Validation failed");
+	});
+
+	it("その他のステータスコードはステータス番号を含むフォールバック文字列を返す", async () => {
+		// Arrange
+		const response = new Response(null, { status: 500 });
+
+		// Act
+		const result = await extractErrorMessage(response);
+
+		// Assert
+		expect(result).toBe("Request failed: 500");
+	});
+});

--- a/source/routes/web.php
+++ b/source/routes/web.php
@@ -46,6 +46,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/horses/{horse}/notes', [HorseNoteController::class, 'index'])->name('api.horses.notes.index');
         Route::post('/horses/{horse}/notes', [HorseNoteController::class, 'store'])->name('api.horses.notes.store');
         Route::put('/horse-notes/{note}', [HorseNoteController::class, 'update'])->name('api.horse-notes.update');
+        Route::delete('/horse-notes/{note}', [HorseNoteController::class, 'destroy'])->name('api.horse-notes.destroy');
     });
 });
 

--- a/source/tests/Feature/HorseNotes/HorseNoteDestroyTest.php
+++ b/source/tests/Feature/HorseNotes/HorseNoteDestroyTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Models\Horse;
+use App\Models\HorseNote;
+use App\Models\User;
+
+/**
+ * horse_notes destroy テスト用の horse を作成して返す
+ */
+function createHorseForHorseNoteDestroyTest(): Horse
+{
+    return Horse::create([
+        'name' => 'デリートテスト用ホース'.uniqid(),
+        'birth_year' => 2022,
+    ]);
+}
+
+// ===== DELETE /api/horse-notes/{note} =====
+
+test('unauthenticated user cannot delete horse note', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $horse = createHorseForHorseNoteDestroyTest();
+    $note = HorseNote::factory()->create([
+        'user_id' => $user->id,
+        'horse_id' => $horse->id,
+        'race_id' => null,
+        'content' => '削除対象メモ',
+    ]);
+
+    // Act
+    $response = $this->deleteJson('/api/horse-notes/'.$note->id);
+
+    // Assert
+    $response->assertUnauthorized();
+});
+
+test('authenticated user can delete own horse note', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $horse = createHorseForHorseNoteDestroyTest();
+    $note = HorseNote::factory()->create([
+        'user_id' => $user->id,
+        'horse_id' => $horse->id,
+        'race_id' => null,
+        'content' => '削除対象メモ',
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->deleteJson('/api/horse-notes/'.$note->id);
+
+    // Assert
+    $response->assertNoContent();
+    $this->assertDatabaseMissing('horse_notes', [
+        'id' => $note->id,
+    ]);
+});
+
+test('deleting other users horse note returns 403', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $horse = createHorseForHorseNoteDestroyTest();
+    $note = HorseNote::factory()->create([
+        'user_id' => $otherUser->id,
+        'horse_id' => $horse->id,
+        'race_id' => null,
+        'content' => '他人のメモ',
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->deleteJson('/api/horse-notes/'.$note->id);
+
+    // Assert
+    $response->assertForbidden();
+});
+
+test('deleting non-existent horse note returns 404', function () {
+    // Arrange
+    $user = User::factory()->create();
+
+    // Act
+    $response = $this->actingAs($user)->deleteJson('/api/horse-notes/9999999');
+
+    // Assert
+    $response->assertNotFound();
+});


### PR DESCRIPTION
## やったこと

- `DELETE /api/horse-notes/{note}` エンドポイントを追加（自分のメモのみ削除可能、他ユーザーは 403、物理削除、成功時 204）
- `DeleteAction` UseCase を `UpdateAction` と同じパターンで新規作成
- 競走馬詳細画面のメモ一覧に各カード右下の「削除」ボタン → 確認ダイアログ → 「削除する」で即時削除されるフローを追加
- 削除確認ダイアログ（`HorseNoteDeleteConfirmDialog`）のコンポーネント・テスト・Storybook を新規作成
- バックエンド Feature テスト 4ケース・フロントエンド単体テスト 7ケース・統合テスト 1ケース（削除フロー）を追加

## 結果

## 動作確認済み

- [ ] 