### PR TITLE
[patch] 出走馬登録画面のレスポンシブ対応

### DIFF
--- a/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.tsx
+++ b/source/resources/js/features/raceEntry/presentational/RaceEntryRegistrationForm/index.tsx
@@ -16,7 +16,7 @@ const RaceEntryRegistrationForm = ({
 	onSubmit,
 }: RaceEntryRegistrationFormProps) => {
 	return (
-		<div className="mx-auto max-w-2xl space-y-8 p-4">
+		<div className="mx-auto max-w-2xl space-y-8 p-4 lg:max-w-4xl lg:p-6">
 			<div>
 				<BackButton
 					label="レース詳細へ戻る"


### PR DESCRIPTION
## やったこと

- 出走馬登録フォーム (`RaceEntryRegistrationForm`) のルートコンテナに `lg:max-w-4xl lg:p-6` を追加し、PC (≥1024px) での表示幅を 672px → 896px に拡大した
- モバイル・タブレット (<1024px) は現状の `max-w-2xl` を維持

## 結果

Storybook の `features/raceEntry/presentational/RaceEntryRegistrationForm` → 各ストーリーで確認。
- **初期状態 / 送信中 / テキスト入力済み**: PCサイズで広めに表示
- **モバイル表示**: スマホサイズでの表示に変化なし

## 動作確認済み

- [x] Storybook で PC 幅・モバイル幅それぞれの表示を確認