### PR TITLE
[minor] レース結果削除フローの追加

### DIFF
--- a/source/app/Exceptions/RaceResult/NoResultToDestroyException.php
+++ b/source/app/Exceptions/RaceResult/NoResultToDestroyException.php
@@ -5,6 +5,4 @@ namespace App\Exceptions\RaceResult;
 /**
  * 削除対象のレース結果（race_result_horses / race_payouts）が存在しないことを表す例外。
  */
-class NoResultToDestroyException extends \RuntimeException
-{
-}
+class NoResultToDestroyException extends \RuntimeException {}

--- a/source/app/Exceptions/RaceResult/NoResultToDestroyException.php
+++ b/source/app/Exceptions/RaceResult/NoResultToDestroyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions\RaceResult;
+
+/**
+ * 削除対象のレース結果（race_result_horses / race_payouts）が存在しないことを表す例外。
+ */
+class NoResultToDestroyException extends \RuntimeException
+{
+}

--- a/source/app/Http/Controllers/RaceResultController.php
+++ b/source/app/Http/Controllers/RaceResultController.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Exceptions\RaceResult\NoResultToDestroyException;
 use App\Exceptions\RaceResult\ParseException;
 use App\Http\Requests\RaceResult\StoreRaceResultRequest;
+use App\UseCases\RaceResult\DestroyAction;
 use App\UseCases\RaceResult\ShowAction;
 use App\UseCases\RaceResult\ShowResultAction;
 use App\UseCases\RaceResult\StoreAction;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -37,5 +40,16 @@ class RaceResultController extends Controller
         return Inertia::render('races/result/edit', [
             'race' => $action->execute($uid, $request->user()),
         ]);
+    }
+
+    public function destroy(string $uid, DestroyAction $action): JsonResponse
+    {
+        try {
+            $action->execute($uid);
+        } catch (NoResultToDestroyException $e) {
+            return response()->json(['message' => $e->getMessage()], 409);
+        }
+
+        return response()->json(['message' => 'レース結果を削除しました']);
     }
 }

--- a/source/app/UseCases/RaceResult/DestroyAction.php
+++ b/source/app/UseCases/RaceResult/DestroyAction.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\UseCases\RaceResult;
+
+use App\Exceptions\RaceResult\NoResultToDestroyException;
+use App\Models\Race;
+use App\Models\TicketPurchase;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * 指定レースの結果（着順・払戻）と、関連する馬券の払戻金額をリセットする。
+ *
+ * race_result_horses と race_payouts （race_payout_horses は cascadeOnDelete で連鎖削除）を削除し、
+ * 同レースの ticket_purchases.payout_amount をユーザー問わず NULL に戻す。
+ */
+class DestroyAction
+{
+    /**
+     * @throws NoResultToDestroyException 削除対象の着順・払戻が一切存在しない場合
+     */
+    public function execute(string $uid): void
+    {
+        $race = Race::where('uid', $uid)->firstOrFail();
+
+        $hasResultHorses = $race->raceResultHorses()->exists();
+        $hasPayouts = $race->racePayouts()->exists();
+
+        if (! $hasResultHorses && ! $hasPayouts) {
+            throw new NoResultToDestroyException('このレースには削除対象の結果がありません。');
+        }
+
+        DB::transaction(function () use ($race): void {
+            $race->racePayouts()->delete();
+            $race->raceResultHorses()->delete();
+
+            TicketPurchase::where('race_id', $race->id)
+                ->update(['payout_amount' => null]);
+        });
+    }
+}

--- a/source/app/UseCases/RaceResult/ShowAction.php
+++ b/source/app/UseCases/RaceResult/ShowAction.php
@@ -21,7 +21,7 @@ class ShowAction
             'venue_name' => $race->venue->name,
             'race_date' => $race->race_date,
             'race_number' => $race->race_number,
-            'has_existing_result' => $race->raceResultHorses()->exists(),
+            'has_existing_result' => $race->raceResultHorses()->exists() || $race->racePayouts()->exists(),
         ];
     }
 }

--- a/source/docs/specs/api-list.md
+++ b/source/docs/specs/api-list.md
@@ -1,0 +1,8 @@
+# API一覧
+
+JSONレスポンスを返すREST APIの一覧。画面（Inertia）を返すルートは含まない。
+
+| メソッド | パス | 操作 | コントローラ#メソッド | 説明 |
+|---------|------|------|----------------------|------|
+| POST | `/races/{uid}/result` | レース結果登録 | `RaceResultController#store` | 着順・払戻データを登録し、ticket_purchases.payout_amountを更新する |
+| DELETE | `/races/{uid}/result` | レース結果削除 | `RaceResultController#destroy` | 着順・払戻データを削除し、ticket_purchases.payout_amountをNULLにリセットする |

--- a/source/docs/specs/er-diagram.md
+++ b/source/docs/specs/er-diagram.md
@@ -1,0 +1,59 @@
+# ER図（レース結果関連）
+
+```mermaid
+erDiagram
+    races {
+        bigint id PK
+        string uid
+        string venue_name
+        date race_date
+        int race_number
+    }
+
+    race_result_horses {
+        bigint id PK
+        bigint race_id FK
+        int finishing_order
+        int frame_number
+        int horse_number
+        string horse_name
+        string jockey_name
+        string race_time
+    }
+
+    race_payouts {
+        bigint id PK
+        bigint race_id FK
+        string ticket_type_name
+        int payout_amount
+        int popularity
+    }
+
+    race_payout_horses {
+        bigint id PK
+        bigint race_payout_id FK
+        int horse_number
+        int sort_order
+    }
+
+    ticket_purchases {
+        bigint id PK
+        bigint race_id FK
+        string ticket_type_name
+        int purchase_amount
+        int|null payout_amount
+    }
+
+    races ||--o{ race_result_horses : "1レースに複数の着順馬"
+    races ||--o{ race_payouts : "1レースに複数の払戻"
+    race_payouts ||--o{ race_payout_horses : "1払戻に複数の対象馬番"
+    races ||--o{ ticket_purchases : "1レースに複数の馬券購入"
+```
+
+## 削除時の連鎖
+
+`race_result_horses` および `race_payouts` は `race_id` に `cascadeOnDelete` が設定されているため、`races` 削除時に自動削除される。
+
+`race_payout_horses` は `race_payout_id` に `cascadeOnDelete` が設定されているため、`race_payouts` 削除時に自動削除される。
+
+`ticket_purchases.payout_amount` は削除制約なし。レース結果削除時にアプリケーション側で `NULL` にリセットする。

--- a/source/docs/specs/openapi.yaml
+++ b/source/docs/specs/openapi.yaml
@@ -1,0 +1,178 @@
+openapi: 3.1.0
+info:
+  title: Keiba DB API
+  version: 0.1.0
+
+paths:
+  /races/{uid}/result:
+    post:
+      summary: レース結果登録
+      operationId: storeRaceResult
+      tags:
+        - RaceResult
+      parameters:
+        - $ref: '#/components/parameters/RaceUid'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StoreRaceResultRequest'
+      responses:
+        '200':
+          description: 登録成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RaceResultResponse'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      summary: レース結果削除
+      description: |
+        指定レースの着順（race_result_horses）・払戻（race_payouts / race_payout_horses）を削除する。
+        削除と同時に ticket_purchases.payout_amount を NULL にリセットする。
+      operationId: destroyRaceResult
+      tags:
+        - RaceResult
+      parameters:
+        - $ref: '#/components/parameters/RaceUid'
+      responses:
+        '200':
+          description: 削除成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: 削除対象のレース結果が存在しない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  parameters:
+    RaceUid:
+      name: uid
+      in: path
+      required: true
+      description: レースUID
+      schema:
+        type: string
+        example: "abc001"
+
+  schemas:
+    StoreRaceResultRequest:
+      type: object
+      required:
+        - finishing_horses
+        - payouts
+      properties:
+        finishing_horses:
+          type: array
+          items:
+            type: object
+            required:
+              - finishing_order
+              - frame_number
+              - horse_number
+              - horse_name
+              - jockey_name
+              - race_time
+            properties:
+              finishing_order:
+                type: integer
+                example: 1
+              frame_number:
+                type: integer
+                example: 2
+              horse_number:
+                type: integer
+                example: 3
+              horse_name:
+                type: string
+                example: "ディープスター"
+              jockey_name:
+                type: string
+                example: "武豊"
+              race_time:
+                type: string
+                example: "1:33.5"
+        payouts:
+          type: array
+          items:
+            type: object
+            required:
+              - ticket_type_name
+              - payout_amount
+              - popularity
+              - horse_numbers
+            properties:
+              ticket_type_name:
+                type: string
+                example: "tansho"
+              payout_amount:
+                type: integer
+                example: 610
+              popularity:
+                type: integer
+                example: 2
+              horse_numbers:
+                type: array
+                items:
+                  type: integer
+                example: [3]
+
+    RaceResultResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "レース結果を登録しました"
+
+    MessageResponse:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          example: "レース結果を削除しました"
+
+    ErrorResponse:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          example: "削除対象のレース結果が存在しません"
+
+  responses:
+    ValidationError:
+      description: バリデーションエラー
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+              errors:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string
+    NotFound:
+      description: リソースが見つからない
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'

--- a/source/docs/specs/screen-list.md
+++ b/source/docs/specs/screen-list.md
@@ -1,0 +1,6 @@
+# 画面一覧（レース結果関連）
+
+| 画面名 | パス | HTTPメソッド | コントローラ#メソッド | 説明 |
+|--------|------|------------|----------------------|------|
+| レース結果入力画面 | `/races/{uid}/result/new` | GET | `RaceResultController#create` | 着順・払戻を入力するフォーム。`has_existing_result=true` の場合は入力欄がdisabled |
+| レース結果確認画面 | `/races/{uid}/result/edit` | GET | `RaceResultController#edit` | 登録済みの着順・払戻を表示する。削除ボタンを表示し、押下で確認モーダルを開く |

--- a/source/resources/js/features/raceResult/components/DeleteResultModal/index.stories.tsx
+++ b/source/resources/js/features/raceResult/components/DeleteResultModal/index.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import DeleteResultModal from ".";
+
+const meta: Meta<typeof DeleteResultModal> = {
+	title: "features/raceResult/components/DeleteResultModal",
+	component: DeleteResultModal,
+	args: {
+		open: true,
+		onConfirm: () => {},
+		onCancel: () => {},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof DeleteResultModal>;
+
+export const Default: Story = {
+	name: "通常状態",
+	args: {
+		isLoading: false,
+		errorMessage: null,
+	},
+};
+
+export const Loading: Story = {
+	name: "削除実行中（ボタンdisabled・ラベル変化）",
+	args: {
+		isLoading: true,
+		errorMessage: null,
+	},
+};
+
+export const WithError: Story = {
+	name: "削除失敗（エラー表示）",
+	args: {
+		isLoading: false,
+		errorMessage: "レース結果の削除に失敗しました。時間をおいて再度お試しください。",
+	},
+};
+
+export const Mobile: Story = {
+	name: "モバイル表示",
+	globals: {
+		viewport: { value: "mobile1", isRotated: false },
+	},
+	args: {
+		isLoading: false,
+		errorMessage: null,
+	},
+};

--- a/source/resources/js/features/raceResult/components/DeleteResultModal/index.tsx
+++ b/source/resources/js/features/raceResult/components/DeleteResultModal/index.tsx
@@ -1,0 +1,63 @@
+import AlertError from "@/components/presentational/AlertError";
+import { Button } from "@/components/shadcn/ui/button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/shadcn/ui/dialog";
+
+type DeleteResultModalProps = {
+	open: boolean;
+	isLoading: boolean;
+	errorMessage: string | null;
+	onConfirm: () => void;
+	onCancel: () => void;
+};
+
+const DeleteResultModal = ({
+	open,
+	isLoading,
+	errorMessage,
+	onConfirm,
+	onCancel,
+}: DeleteResultModalProps) => {
+	return (
+		<Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) { onCancel(); } }}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>レース結果を削除</DialogTitle>
+					<DialogDescription>
+						このレースの着順・払戻データをすべて削除します。この操作は取り消せません。
+					</DialogDescription>
+				</DialogHeader>
+
+				{errorMessage !== null && (
+					<AlertError errors={[errorMessage]} title="エラー" />
+				)}
+
+				<DialogFooter>
+					<DialogClose asChild>
+						<Button variant="outline" disabled={isLoading} onClick={onCancel}>
+							キャンセル
+						</Button>
+					</DialogClose>
+					<Button
+						variant="destructive"
+						onClick={onConfirm}
+						disabled={isLoading}
+					>
+						{isLoading ? "削除中..." : "削除する"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+export default DeleteResultModal;
+
+export type { DeleteResultModalProps };

--- a/source/resources/js/features/raceResult/components/DeleteResultModal/index.unit.test.tsx
+++ b/source/resources/js/features/raceResult/components/DeleteResultModal/index.unit.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import DeleteResultModal from "./index";
+
+const noop = () => {};
+
+describe("DeleteResultModal", () => {
+	describe("通常状態（isLoading=false, errorMessage=null）", () => {
+		it("タイトルと説明が表示される", () => {
+			// Act
+			render(
+				<DeleteResultModal
+					open={true}
+					isLoading={false}
+					errorMessage={null}
+					onConfirm={noop}
+					onCancel={noop}
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByText("レース結果を削除")).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					"このレースの着順・払戻データをすべて削除します。この操作は取り消せません。",
+				),
+			).toBeInTheDocument();
+		});
+
+		it("「削除する」ボタンと「キャンセル」ボタンが表示される", () => {
+			// Act
+			render(
+				<DeleteResultModal
+					open={true}
+					isLoading={false}
+					errorMessage={null}
+					onConfirm={noop}
+					onCancel={noop}
+				/>,
+			);
+
+			// Assert
+			expect(
+				screen.getByRole("button", { name: "削除する" }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: "キャンセル" }),
+			).toBeInTheDocument();
+		});
+
+		it("エラーメッセージが表示されない", () => {
+			// Act
+			render(
+				<DeleteResultModal
+					open={true}
+					isLoading={false}
+					errorMessage={null}
+					onConfirm={noop}
+					onCancel={noop}
+				/>,
+			);
+
+			// Assert
+			expect(screen.queryByText("エラー")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("削除実行中（isLoading=true）", () => {
+		it("「削除中...」が表示される", () => {
+			// Act
+			render(
+				<DeleteResultModal
+					open={true}
+					isLoading={true}
+					errorMessage={null}
+					onConfirm={noop}
+					onCancel={noop}
+				/>,
+			);
+
+			// Assert
+			expect(
+				screen.getByRole("button", { name: "削除中..." }),
+			).toBeInTheDocument();
+		});
+
+		it("削除ボタンが disabled になる", () => {
+			// Act
+			render(
+				<DeleteResultModal
+					open={true}
+					isLoading={true}
+					errorMessage={null}
+					onConfirm={noop}
+					onCancel={noop}
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByRole("button", { name: "削除中..." })).toBeDisabled();
+		});
+
+		it("キャンセルボタンが disabled になる", () => {
+			// Act
+			render(
+				<DeleteResultModal
+					open={true}
+					isLoading={true}
+					errorMessage={null}
+					onConfirm={noop}
+					onCancel={noop}
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByRole("button", { name: "キャンセル" })).toBeDisabled();
+		});
+	});
+
+	describe("エラー表示（errorMessage が設定されている）", () => {
+		it("エラーメッセージが表示される", () => {
+			// Act
+			render(
+				<DeleteResultModal
+					open={true}
+					isLoading={false}
+					errorMessage="削除に失敗しました"
+					onConfirm={noop}
+					onCancel={noop}
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByText("削除に失敗しました")).toBeInTheDocument();
+		});
+	});
+
+	describe("非表示（open=false）", () => {
+		it("タイトルが表示されない", () => {
+			// Act
+			render(
+				<DeleteResultModal
+					open={false}
+					isLoading={false}
+					errorMessage={null}
+					onConfirm={noop}
+					onCancel={noop}
+				/>,
+			);
+
+			// Assert
+			expect(screen.queryByText("レース結果を削除")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("コールバック", () => {
+		it("「削除する」ボタンをクリックすると onConfirm が呼ばれる", async () => {
+			// Arrange
+			const onConfirm = vi.fn();
+			const user = userEvent.setup();
+
+			// Act
+			render(
+				<DeleteResultModal
+					open={true}
+					isLoading={false}
+					errorMessage={null}
+					onConfirm={onConfirm}
+					onCancel={noop}
+				/>,
+			);
+			await user.click(screen.getByRole("button", { name: "削除する" }));
+
+			// Assert
+			expect(onConfirm).toHaveBeenCalledTimes(1);
+		});
+
+		it("「キャンセル」ボタンをクリックすると onCancel が呼ばれる", async () => {
+			// Arrange
+			const onCancel = vi.fn();
+			const user = userEvent.setup();
+
+			// Act
+			render(
+				<DeleteResultModal
+					open={true}
+					isLoading={false}
+					errorMessage={null}
+					onConfirm={noop}
+					onCancel={onCancel}
+				/>,
+			);
+			await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+			// Assert
+			expect(onCancel).toHaveBeenCalled();
+		});
+	});
+});

--- a/source/resources/js/features/raceResult/containers/RaceResultDetailContainer/index.tsx
+++ b/source/resources/js/features/raceResult/containers/RaceResultDetailContainer/index.tsx
@@ -1,12 +1,15 @@
+import { router } from "@inertiajs/react";
+import { useState } from "react";
 import HorseNoteModalContainer from "@/features/horseNote/containers/HorseNoteModalContainer";
 import type { HorseNote } from "@/features/horseNote/types/horseNote";
+import DeleteResultModal from "@/features/raceResult/components/DeleteResultModal";
 import RaceResultDetail from "@/features/raceResult/presentational/RaceResultDetail";
 import type {
 	FinishingHorse,
 	RaceResultDetailProps,
 } from "@/features/raceResult/presentational/RaceResultDetail/types";
+import { deleteRaceResult } from "@/features/raceResult/requests/raceResults";
 import { formatDateDisplay } from "@/utils/date";
-import { useState } from "react";
 
 type RaceProps = RaceResultDetailProps["race"] & {
 	id?: number;
@@ -25,6 +28,7 @@ const buildRaceLabel = (race: RaceProps): string => {
 /**
  * レース結果画面のコンテナ。
  * メモセルのクリックでモーダルを開き、API 成功時に finishing_horses の note を更新する。
+ * 「レース結果を削除」ボタンで削除確認モーダルを表示し、確定時に DELETE API を呼んで結果入力画面に遷移する。
  */
 const RaceResultDetailContainer = ({ race }: Props) => {
 	const [finishingHorses, setFinishingHorses] = useState<FinishingHorse[]>(
@@ -35,6 +39,11 @@ const RaceResultDetailContainer = ({ race }: Props) => {
 		horseId: number | null;
 		horseName: string;
 	}>({ open: false, horseId: null, horseName: "" });
+	const [deleteModal, setDeleteModal] = useState<{
+		open: boolean;
+		isLoading: boolean;
+		errorMessage: string | null;
+	}>({ open: false, isLoading: false, errorMessage: null });
 
 	const handleNoteClick = (horseId: number) => {
 		const target = finishingHorses.find((h) => h.horse_id === horseId);
@@ -70,6 +79,36 @@ const RaceResultDetailContainer = ({ race }: Props) => {
 		);
 	};
 
+	const handleDeleteClick = () => {
+		setDeleteModal({ open: true, isLoading: false, errorMessage: null });
+	};
+
+	const handleDeleteCancel = () => {
+		setDeleteModal({ open: false, isLoading: false, errorMessage: null });
+	};
+
+	const handleDeleteConfirm = async () => {
+		setDeleteModal((current) => ({
+			...current,
+			isLoading: true,
+			errorMessage: null,
+		}));
+		try {
+			await deleteRaceResult(race.uid);
+			router.visit(`/races/${race.uid}/result/new`);
+		} catch (error) {
+			const message =
+				error instanceof Error
+					? error.message
+					: "レース結果の削除に失敗しました。時間をおいて再度お試しください。";
+			setDeleteModal({
+				open: true,
+				isLoading: false,
+				errorMessage: message,
+			});
+		}
+	};
+
 	const localRace = { ...race, finishing_horses: finishingHorses };
 	const selectedHorse =
 		noteModal.horseId != null
@@ -79,7 +118,11 @@ const RaceResultDetailContainer = ({ race }: Props) => {
 
 	return (
 		<>
-			<RaceResultDetail race={localRace} onNoteClick={handleNoteClick} />
+			<RaceResultDetail
+				race={localRace}
+				onNoteClick={handleNoteClick}
+				onDeleteClick={handleDeleteClick}
+			/>
 			{noteModal.horseId != null && (
 				<HorseNoteModalContainer
 					open={noteModal.open}
@@ -98,6 +141,13 @@ const RaceResultDetailContainer = ({ race }: Props) => {
 					onSuccess={handleNoteSuccess}
 				/>
 			)}
+			<DeleteResultModal
+				open={deleteModal.open}
+				isLoading={deleteModal.isLoading}
+				errorMessage={deleteModal.errorMessage}
+				onConfirm={handleDeleteConfirm}
+				onCancel={handleDeleteCancel}
+			/>
 		</>
 	);
 };

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof RaceResultDetail> = {
 	component: RaceResultDetail,
 	args: {
 		onNoteClick: () => {},
+		onDeleteClick: () => {},
 	},
 };
 

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/index.tsx
@@ -8,7 +8,7 @@ import { formatDateDisplay } from "@/utils/date";
 import type { RaceResultDetailProps } from "./types";
 import { formatHorseNumbers } from "./utils";
 
-const RaceResultDetail = ({ race, onNoteClick }: RaceResultDetailProps) => {
+const RaceResultDetail = ({ race, onNoteClick, onDeleteClick }: RaceResultDetailProps) => {
 	return (
 		<div className="flex flex-col gap-4 p-4">
 			<div>
@@ -22,13 +22,24 @@ const RaceResultDetail = ({ race, onNoteClick }: RaceResultDetailProps) => {
 						{race.race_number}R
 					</p>
 				</div>
-				{race.finishing_horses.length === 0 && (
-					<Button asChild variant="outline" size="sm">
-						<Link href={`/races/${race.uid}/result/new`}>
-							レース結果入力
-						</Link>
-					</Button>
-				)}
+				<div className="flex items-center gap-2">
+					{race.finishing_horses.length === 0 && (
+						<Button asChild variant="outline" size="sm">
+							<Link href={`/races/${race.uid}/result/new`}>
+								レース結果入力
+							</Link>
+						</Button>
+					)}
+					{race.finishing_horses.length > 0 && onDeleteClick !== undefined && (
+						<Button
+							variant="destructive"
+							size="sm"
+							onClick={onDeleteClick}
+						>
+							レース結果を削除
+						</Button>
+					)}
+				</div>
 			</div>
 
 			<div className="flex flex-col gap-2">

--- a/source/resources/js/features/raceResult/presentational/RaceResultDetail/types.ts
+++ b/source/resources/js/features/raceResult/presentational/RaceResultDetail/types.ts
@@ -36,4 +36,5 @@ export type RaceResultDetailProps = {
 		finishing_horses: FinishingHorse[];
 	};
 	onNoteClick?: (horseId: number) => void;
+	onDeleteClick?: () => void;
 };

--- a/source/resources/js/features/raceResult/requests/raceResults.ts
+++ b/source/resources/js/features/raceResult/requests/raceResults.ts
@@ -1,0 +1,38 @@
+import { buildJsonHeaders } from "@/features/raceDetail/requests/csrf";
+
+type ErrorBody = {
+	message?: string;
+};
+
+const GENERIC_ERROR_MESSAGE =
+	"レース結果の削除に失敗しました。時間をおいて再度お試しください。";
+
+const extractErrorMessage = async (response: Response): Promise<string> => {
+	if (response.status === 409) {
+		try {
+			const json = (await response.json()) as ErrorBody;
+			if (json.message != null && json.message !== "") {
+				return json.message;
+			}
+		} catch (_e) {
+			// JSON parse 失敗時はフォールバック
+		}
+	}
+	return GENERIC_ERROR_MESSAGE;
+};
+
+/**
+ * 指定レースの結果（着順・払戻）を削除する。成功時は 200。
+ */
+export const deleteRaceResult = async (raceUid: string): Promise<void> => {
+	const response = await fetch(`/races/${raceUid}/result`, {
+		method: "DELETE",
+		headers: buildJsonHeaders(),
+		credentials: "same-origin",
+	});
+
+	if (!response.ok) {
+		const message = await extractErrorMessage(response);
+		throw new Error(message);
+	}
+};

--- a/source/routes/web.php
+++ b/source/routes/web.php
@@ -34,6 +34,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/races/{uid}/result/new', [RaceResultController::class, 'create'])->name('races.result.create');
     Route::post('/races/{uid}/result', [RaceResultController::class, 'store'])->name('races.result.store');
     Route::get('/races/{uid}/result/edit', [RaceResultController::class, 'edit'])->name('races.result.edit');
+    Route::delete('/races/{uid}/result', [RaceResultController::class, 'destroy'])->name('races.result.destroy');
 
     Route::get('/horses/{horse}', [HorseController::class, 'show'])->name('horses.show');
 

--- a/source/tests/Feature/Races/RaceResultDestroyTest.php
+++ b/source/tests/Feature/Races/RaceResultDestroyTest.php
@@ -1,0 +1,265 @@
+<?php
+
+use App\Models\User;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * @return array{venueId: int, now: CarbonInterface}
+ */
+function createRaceResultMasterDataForDestroyTest(): array
+{
+    $now = now();
+
+    DB::table('venues')->insert([
+        'name' => '東京',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+    $venueId = DB::table('venues')->where('name', '東京')->value('id');
+
+    $ticketTypes = [
+        ['name' => 'tansho', 'label' => '単勝', 'sort_order' => 1],
+        ['name' => 'fukusho', 'label' => '複勝', 'sort_order' => 2],
+        ['name' => 'wakuren', 'label' => '枠連', 'sort_order' => 3],
+        ['name' => 'umaren', 'label' => '馬連', 'sort_order' => 4],
+        ['name' => 'umatan', 'label' => '馬単', 'sort_order' => 5],
+        ['name' => 'wide', 'label' => 'ワイド', 'sort_order' => 6],
+        ['name' => 'sanrenpuku', 'label' => '3連複', 'sort_order' => 7],
+        ['name' => 'sanrentan', 'label' => '3連単', 'sort_order' => 8],
+    ];
+
+    foreach ($ticketTypes as $ticketType) {
+        DB::table('ticket_types')->insert([
+            'name' => $ticketType['name'],
+            'label' => $ticketType['label'],
+            'sort_order' => $ticketType['sort_order'],
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    return compact('venueId', 'now');
+}
+
+/**
+ * @return array{raceId: int, raceUid: string}
+ */
+function createRaceWithUidForDestroyTest(int $venueId, CarbonInterface $now, int $raceNumber = 1): array
+{
+    $raceUid = 'test-uid-'.uniqid();
+    $raceId = DB::table('races')->insertGetId([
+        'uid' => $raceUid,
+        'venue_id' => $venueId,
+        'race_date' => '2026-04-05',
+        'race_number' => $raceNumber,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    return compact('raceId', 'raceUid');
+}
+
+function createBuyTypesForDestroyTest(CarbonInterface $now): int
+{
+    $buyTypes = [
+        ['name' => 'single', 'label' => '通常', 'sort_order' => 1],
+        ['name' => 'nagashi', 'label' => '流し', 'sort_order' => 2],
+        ['name' => 'box', 'label' => 'ボックス', 'sort_order' => 3],
+        ['name' => 'formation', 'label' => 'フォーメーション', 'sort_order' => 4],
+    ];
+
+    foreach ($buyTypes as $buyType) {
+        DB::table('buy_types')->insertOrIgnore([
+            'name' => $buyType['name'],
+            'label' => $buyType['label'],
+            'sort_order' => $buyType['sort_order'],
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    return DB::table('buy_types')->where('name', 'single')->value('id');
+}
+
+/**
+ * 指定レースに race_result_horses / race_payouts / race_payout_horses を作成する。
+ */
+function seedRaceResultForDestroyTest(int $raceId, CarbonInterface $now): void
+{
+    DB::table('race_result_horses')->insert([
+        [
+            'race_id' => $raceId,
+            'finishing_order' => 1,
+            'frame_number' => 2,
+            'horse_number' => 3,
+            'horse_name' => 'テスト馬A',
+            'sex_age' => '牡3',
+            'weight' => '57.0',
+            'jockey_name' => '騎手A',
+            'race_time' => '1:34.5',
+            'trainer_name' => '調教師A',
+            'popularity' => 1,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ],
+        [
+            'race_id' => $raceId,
+            'finishing_order' => 2,
+            'frame_number' => 4,
+            'horse_number' => 7,
+            'horse_name' => 'テスト馬B',
+            'sex_age' => '牝4',
+            'weight' => '55.0',
+            'jockey_name' => '騎手B',
+            'race_time' => '1:34.8',
+            'trainer_name' => '調教師B',
+            'popularity' => 3,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ],
+    ]);
+
+    $tanshoTicketTypeId = DB::table('ticket_types')->where('name', 'tansho')->value('id');
+    $payoutId = DB::table('race_payouts')->insertGetId([
+        'race_id' => $raceId,
+        'ticket_type_id' => $tanshoTicketTypeId,
+        'payout_amount' => 610,
+        'popularity' => 2,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    DB::table('race_payout_horses')->insert([
+        'race_payout_id' => $payoutId,
+        'horse_number' => 3,
+        'sort_order' => 1,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+}
+
+// ===== DELETE /races/{uid}/result =====
+
+test('authenticated user can delete race result and related records are removed', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterDataForDestroyTest();
+    ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUidForDestroyTest($venueId, $now);
+    seedRaceResultForDestroyTest($raceId, $now);
+
+    // Act
+    $response = $this->actingAs($user)->deleteJson(route('races.result.destroy', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertOk();
+    $response->assertJsonStructure(['message']);
+    expect(DB::table('race_result_horses')->where('race_id', $raceId)->count())->toBe(0);
+    expect(DB::table('race_payouts')->where('race_id', $raceId)->count())->toBe(0);
+    expect(DB::table('race_payout_horses')->count())->toBe(0);
+});
+
+test('deleting race result resets ticket_purchases.payout_amount to null only for target race', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterDataForDestroyTest();
+    ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUidForDestroyTest($venueId, $now, 1);
+    ['raceId' => $otherRaceId] = createRaceWithUidForDestroyTest($venueId, $now, 2);
+    seedRaceResultForDestroyTest($raceId, $now);
+    $singleBuyTypeId = createBuyTypesForDestroyTest($now);
+
+    $tanshoTicketTypeId = DB::table('ticket_types')->where('name', 'tansho')->value('id');
+
+    // 対象レースの馬券（payout_amount あり、削除でNULLにリセットされる）
+    $targetPurchaseId = DB::table('ticket_purchases')->insertGetId([
+        'user_id' => $user->id,
+        'race_id' => $raceId,
+        'ticket_type_id' => $tanshoTicketTypeId,
+        'buy_type_id' => $singleBuyTypeId,
+        'selections' => json_encode(['horses' => [3]]),
+        'amount' => 100,
+        'payout_amount' => 610,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // 対象レース・別ユーザーの馬券（同じくNULLにリセットされる：レース全体に対する操作）
+    $otherUserPurchaseId = DB::table('ticket_purchases')->insertGetId([
+        'user_id' => $otherUser->id,
+        'race_id' => $raceId,
+        'ticket_type_id' => $tanshoTicketTypeId,
+        'buy_type_id' => $singleBuyTypeId,
+        'selections' => json_encode(['horses' => [3]]),
+        'amount' => 100,
+        'payout_amount' => 610,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // 別レースの馬券（影響を受けない）
+    $otherRacePurchaseId = DB::table('ticket_purchases')->insertGetId([
+        'user_id' => $user->id,
+        'race_id' => $otherRaceId,
+        'ticket_type_id' => $tanshoTicketTypeId,
+        'buy_type_id' => $singleBuyTypeId,
+        'selections' => json_encode(['horses' => [3]]),
+        'amount' => 100,
+        'payout_amount' => 1000,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // Act
+    $this->actingAs($user)->deleteJson(route('races.result.destroy', ['uid' => $raceUid]));
+
+    // Assert
+    $this->assertDatabaseHas('ticket_purchases', [
+        'id' => $targetPurchaseId,
+        'payout_amount' => null,
+    ]);
+    $this->assertDatabaseHas('ticket_purchases', [
+        'id' => $otherUserPurchaseId,
+        'payout_amount' => null,
+    ]);
+    $this->assertDatabaseHas('ticket_purchases', [
+        'id' => $otherRacePurchaseId,
+        'payout_amount' => 1000,
+    ]);
+});
+
+test('unauthenticated user is redirected to login page when deleting race result', function () {
+    // Arrange
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterDataForDestroyTest();
+    ['raceUid' => $raceUid] = createRaceWithUidForDestroyTest($venueId, $now);
+
+    // Act
+    $response = $this->delete(route('races.result.destroy', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertRedirect(route('login'));
+});
+
+test('deleting race result with non-existent uid returns 404', function () {
+    // Arrange
+    $user = User::factory()->create();
+
+    // Act
+    $response = $this->actingAs($user)->deleteJson(route('races.result.destroy', ['uid' => 'non-existent-uid']));
+
+    // Assert
+    $response->assertNotFound();
+});
+
+test('deleting race result returns 409 when no result exists for the race', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterDataForDestroyTest();
+    ['raceUid' => $raceUid] = createRaceWithUidForDestroyTest($venueId, $now);
+
+    // Act
+    $response = $this->actingAs($user)->deleteJson(route('races.result.destroy', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertStatus(409);
+});

--- a/source/tests/Feature/Races/RaceResultTest.php
+++ b/source/tests/Feature/Races/RaceResultTest.php
@@ -207,6 +207,32 @@ test('race result create page returns has_existing_result as true when race resu
     );
 });
 
+test('race result create page returns has_existing_result as true when only race_payouts exist', function () {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    $tanshoTicketTypeId = DB::table('ticket_types')->where('name', 'tansho')->value('id');
+    DB::table('race_payouts')->insert([
+        'race_id' => $raceId,
+        'ticket_type_id' => $tanshoTicketTypeId,
+        'payout_amount' => 610,
+        'popularity' => 2,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('races.result.create', ['uid' => $raceUid]));
+
+    // Assert
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('races/result/create')
+        ->where('race.has_existing_result', true)
+    );
+});
+
 // ===== POST /races/{uid}/result =====
 
 test('valid payout text is stored with 8 race_payouts records', function () use ($sampleText, $resultSampleText) {


### PR DESCRIPTION
## やったこと

- レース結果削除ユースケース（`DestroyAction`）と `RaceResultController#destroy` エンドポイントを実装
- 削除確認モーダル（`DeleteResultModal`）コンポーネントをレース結果詳細画面に追加
- 削除対象が存在しない場合の例外（`NoResultToDestroyException`）を追加
- OpenAPI 定義・ER 図・API 一覧・画面一覧ドキュメントを更新
- 削除フローのフィーチャーテスト（`RaceResultDestroyTest`）とフロントエンドユニットテストを追加

## 結果

<\!-- スクリーンショット・動画を添付する -->

## 動作確認済み

- [ ] 