### PR TITLE
[patch] RaceController::index/create の UseCase 抽出

### DIFF
--- a/source/app/Http/Controllers/RaceController.php
+++ b/source/app/Http/Controllers/RaceController.php
@@ -4,10 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\Race\StoreRaceRequest;
 use App\Models\Race;
-use App\Models\Venue;
+use App\UseCases\Race\CreateAction;
+use App\UseCases\Race\IndexAction;
 use App\UseCases\Race\ShowAction;
 use App\UseCases\Race\StoreAction;
-use Carbon\CarbonInterface;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -15,49 +15,24 @@ use Inertia\Response;
 
 class RaceController extends Controller
 {
-    public function index(Request $request): Response
+    public function index(Request $request, IndexAction $action): Response
     {
         $venueId = $request->query('venue_id');
         $raceDate = $request->query('race_date');
 
-        return Inertia::render('races/index', [
-            'races' => $raceDate ? Race::query()
-                ->with('venue')
-                ->where('race_date', $raceDate)
-                ->when($venueId, fn ($q, $id) => $q->where('venue_id', $id))
-                ->orderBy('venue_id')
-                ->orderBy('race_number')
-                ->get()
-                ->map(fn (Race $race) => [
-                    'uid' => $race->uid,
-                    'race_date' => $race->race_date instanceof CarbonInterface
-                        ? $race->race_date->format('Y-m-d')
-                        : (string) $race->race_date,
-                    'venue_name' => $race->venue->name,
-                    'race_number' => $race->race_number,
-                    'race_name' => $race->race_name,
-                ]) : [],
-            'venues' => $raceDate
-                ? Venue::query()
-                    ->whereHas('races', fn ($q) => $q->where('race_date', $raceDate))
-                    ->orderBy('id')
-                    ->get(['id', 'name'])
-                : collect(),
-            'filters' => [
-                'race_date' => $raceDate,
-                'venue_id' => $venueId !== null ? (int) $venueId : null,
-            ],
-        ]);
+        return Inertia::render('races/index', $action->execute(
+            $raceDate !== null ? (string) $raceDate : null,
+            $venueId !== null ? (int) $venueId : null,
+        ));
     }
 
-    public function create(Request $request): Response
+    public function create(Request $request, CreateAction $action): Response
     {
-        return Inertia::render('races/new', [
-            'venues' => Venue::query()->orderBy('id')->get(['id', 'name']),
-            'last_venue_id' => $request->session()->get('last_venue_id'),
-            'last_race_date' => $request->session()->get('last_race_date'),
-            'last_race_number' => $request->session()->get('last_race_number'),
-        ]);
+        return Inertia::render('races/new', $action->execute(
+            $request->session()->get('last_venue_id'),
+            $request->session()->get('last_race_date'),
+            $request->session()->get('last_race_number'),
+        ));
     }
 
     public function store(StoreRaceRequest $request, StoreAction $action): RedirectResponse

--- a/source/app/Http/Controllers/RaceController.php
+++ b/source/app/Http/Controllers/RaceController.php
@@ -28,10 +28,14 @@ class RaceController extends Controller
 
     public function create(Request $request, CreateAction $action): Response
     {
+        $lastVenueId = $request->session()->get('last_venue_id');
+        $lastRaceDate = $request->session()->get('last_race_date');
+        $lastRaceNumber = $request->session()->get('last_race_number');
+
         return Inertia::render('races/new', $action->execute(
-            $request->session()->get('last_venue_id'),
-            $request->session()->get('last_race_date'),
-            $request->session()->get('last_race_number'),
+            $lastVenueId !== null ? (int) $lastVenueId : null,
+            $lastRaceDate !== null ? (string) $lastRaceDate : null,
+            $lastRaceNumber !== null ? (int) $lastRaceNumber : null,
         ));
     }
 

--- a/source/app/UseCases/Race/CreateAction.php
+++ b/source/app/UseCases/Race/CreateAction.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\UseCases\Race;
+
+use App\Models\Venue;
+use Illuminate\Support\Collection;
+
+/**
+ * レース新規登録画面の表示用データを返す。
+ *
+ * 競馬場一覧と、直前に登録したレースのセッション値（次回入力時のデフォルト用）を返す。
+ */
+class CreateAction
+{
+    /**
+     * @return array{
+     *     venues: Collection<int, Venue>,
+     *     last_venue_id: int|null,
+     *     last_race_date: string|null,
+     *     last_race_number: int|null,
+     * }
+     */
+    public function execute(?int $lastVenueId, ?string $lastRaceDate, ?int $lastRaceNumber): array
+    {
+        return [
+            'venues' => Venue::query()->orderBy('id')->get(['id', 'name']),
+            'last_venue_id' => $lastVenueId,
+            'last_race_date' => $lastRaceDate,
+            'last_race_number' => $lastRaceNumber,
+        ];
+    }
+}

--- a/source/app/UseCases/Race/IndexAction.php
+++ b/source/app/UseCases/Race/IndexAction.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\UseCases\Race;
+
+use App\Models\Race;
+use App\Models\Venue;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Collection;
+
+/**
+ * レース一覧画面の表示用データを返す。
+ *
+ * race_date 指定時はその日付のレース・競馬場を返し、未指定時は races を空配列・venues を空コレクションとする。
+ * venue_id は race_date 指定時のみレース絞り込みに使われる。
+ */
+class IndexAction
+{
+    /**
+     * @return array{
+     *     races: Collection<int, array{
+     *         uid: string,
+     *         race_date: string,
+     *         venue_name: string,
+     *         race_number: int,
+     *         race_name: string|null,
+     *     }>|array<int, mixed>,
+     *     venues: Collection<int, Venue>,
+     *     filters: array{race_date: string|null, venue_id: int|null},
+     * }
+     */
+    public function execute(?string $raceDate, ?int $venueId): array
+    {
+        $races = $raceDate ? Race::query()
+            ->with('venue')
+            ->where('race_date', $raceDate)
+            ->when($venueId, fn ($q, $id) => $q->where('venue_id', $id))
+            ->orderBy('venue_id')
+            ->orderBy('race_number')
+            ->get()
+            ->map(fn (Race $race) => [
+                'uid' => $race->uid,
+                'race_date' => $race->race_date instanceof CarbonInterface
+                    ? $race->race_date->format('Y-m-d')
+                    : (string) $race->race_date,
+                'venue_name' => $race->venue->name,
+                'race_number' => $race->race_number,
+                'race_name' => $race->race_name,
+            ]) : [];
+
+        $venues = $raceDate
+            ? Venue::query()
+                ->whereHas('races', fn ($q) => $q->where('race_date', $raceDate))
+                ->orderBy('id')
+                ->get(['id', 'name'])
+            : collect();
+
+        return [
+            'races' => $races,
+            'venues' => $venues,
+            'filters' => [
+                'race_date' => $raceDate,
+                'venue_id' => $venueId,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## やったこと

- `RaceController::index` のクエリ・データ整形ロジックを `App\UseCases\Race\IndexAction` に抽出
- `RaceController::create` の venues 取得ロジックを `App\UseCases\Race\CreateAction` に抽出
- コントローラーは UseCase への委譲のみを行う薄い層に整理

## 結果

## 動作確認済み

- [ ] 