### PR TITLE
[minor] race_date クエリパラメータをレース作成画面に引き継ぐ

### DIFF
--- a/source/app/Http/Controllers/RaceController.php
+++ b/source/app/Http/Controllers/RaceController.php
@@ -29,7 +29,11 @@ class RaceController extends Controller
     public function create(Request $request, CreateAction $action): Response
     {
         $lastVenueId = $request->session()->get('last_venue_id');
-        $lastRaceDate = $request->query('race_date') ?? $request->session()->get('last_race_date');
+        $queryRaceDate = $request->query('race_date');
+        if ($queryRaceDate !== null && preg_match('/^\d{4}-\d{2}-\d{2}$/', (string) $queryRaceDate) !== 1) {
+            $queryRaceDate = null;
+        }
+        $lastRaceDate = $queryRaceDate ?? $request->session()->get('last_race_date');
         $lastRaceNumber = $request->session()->get('last_race_number');
 
         return Inertia::render('races/new', $action->execute(

--- a/source/app/Http/Controllers/RaceController.php
+++ b/source/app/Http/Controllers/RaceController.php
@@ -29,7 +29,7 @@ class RaceController extends Controller
     public function create(Request $request, CreateAction $action): Response
     {
         $lastVenueId = $request->session()->get('last_venue_id');
-        $lastRaceDate = $request->session()->get('last_race_date');
+        $lastRaceDate = $request->query('race_date') ?? $request->session()->get('last_race_date');
         $lastRaceNumber = $request->session()->get('last_race_number');
 
         return Inertia::render('races/new', $action->execute(

--- a/source/resources/js/features/raceList/presentational/RaceList/RaceList.unit.test.tsx
+++ b/source/resources/js/features/raceList/presentational/RaceList/RaceList.unit.test.tsx
@@ -15,8 +15,10 @@ vi.mock("@inertiajs/react", () => ({
 
 vi.mock("@/routes/races", () => ({
 	create: {
-		url: ({ race_date }: { race_date?: string } = {}) =>
-			race_date ? `/races/new?race_date=${race_date}` : "/races/new",
+		url: (options?: { query?: { race_date?: string } }) =>
+			options?.query?.race_date
+				? `/races/new?race_date=${options.query.race_date}`
+				: "/races/new",
 	},
 	show: {
 		url: ({ race }: { race: string }) => `/races/${race}`,

--- a/source/resources/js/features/raceList/presentational/RaceList/RaceList.unit.test.tsx
+++ b/source/resources/js/features/raceList/presentational/RaceList/RaceList.unit.test.tsx
@@ -15,7 +15,8 @@ vi.mock("@inertiajs/react", () => ({
 
 vi.mock("@/routes/races", () => ({
 	create: {
-		url: () => "/races/new",
+		url: ({ race_date }: { race_date?: string } = {}) =>
+			race_date ? `/races/new?race_date=${race_date}` : "/races/new",
 	},
 	show: {
 		url: ({ race }: { race: string }) => `/races/${race}`,
@@ -82,6 +83,27 @@ describe("RaceList", () => {
 			).toBeGreaterThanOrEqual(1);
 		});
 
+		it("空状態の「レース情報入力」リンクも race_date クエリ付きになる", () => {
+			// Act
+			render(
+				<RaceList
+					{...baseProps}
+					races={[]}
+					selectedDate="2026-04-05"
+				/>,
+			);
+
+			// Assert（ヘッダーと空状態の両方のリンクが race_date クエリ付きであることを確認）
+			const links = screen.getAllByText("レース情報入力");
+			expect(links.length).toBeGreaterThanOrEqual(2);
+			for (const link of links) {
+				expect(link).toHaveAttribute(
+					"href",
+					"/races/new?race_date=2026-04-05",
+				);
+			}
+		});
+
 		it("テーブルが表示されない", () => {
 			// Act
 			render(<RaceList {...baseProps} races={[]} />);
@@ -143,13 +165,16 @@ describe("RaceList", () => {
 			expect(screen.getByText("レース情報入力")).toBeInTheDocument();
 		});
 
-		it("「レース情報入力」リンクの遷移先が /races/new である", () => {
+		it("「レース情報入力」リンクが selectedDate を race_date クエリパラメータに含む URL になる", () => {
 			// Act
-			render(<RaceList {...baseProps} />);
+			render(<RaceList {...baseProps} selectedDate="2026-04-05" />);
 
 			// Assert
 			const link = screen.getByText("レース情報入力");
-			expect(link).toHaveAttribute("href", "/races/new");
+			expect(link).toHaveAttribute(
+				"href",
+				"/races/new?race_date=2026-04-05",
+			);
 		});
 
 		it("race_name が表示される", () => {

--- a/source/resources/js/features/raceList/presentational/RaceList/RaceList.unit.test.tsx
+++ b/source/resources/js/features/raceList/presentational/RaceList/RaceList.unit.test.tsx
@@ -179,6 +179,15 @@ describe("RaceList", () => {
 			);
 		});
 
+		it("selectedDate が空のときは「レース情報入力」リンクの遷移先が /races/new になる", () => {
+			// Act
+			render(<RaceList {...baseProps} selectedDate="" />);
+
+			// Assert
+			const link = screen.getByText("レース情報入力");
+			expect(link).toHaveAttribute("href", "/races/new");
+		});
+
 		it("race_name が表示される", () => {
 			// Act
 			render(<RaceList {...baseProps} />);

--- a/source/resources/js/features/raceList/presentational/RaceList/index.tsx
+++ b/source/resources/js/features/raceList/presentational/RaceList/index.tsx
@@ -15,17 +15,15 @@ const RaceList = ({
 	onDateChange,
 	onVenueChange,
 }: RaceListProps) => {
+	const createRaceUrl = create.url({
+		query: { race_date: selectedDate || undefined },
+	});
+
 	return (
 		<div className="flex flex-col gap-4 p-4">
 			<div className="flex items-center justify-between">
 				<h1 className="text-xl font-semibold">レース一覧</h1>
-				<Link
-					href={create.url({
-						query: { race_date: selectedDate || undefined },
-					})}
-				>
-					レース情報入力
-				</Link>
+				<Link href={createRaceUrl}>レース情報入力</Link>
 			</div>
 
 			<div className="flex flex-wrap gap-4">
@@ -68,13 +66,7 @@ const RaceList = ({
 			{races.length === 0 ? (
 				<div className="flex flex-col items-center justify-center gap-4 py-16 text-muted-foreground">
 					<p>レースが見つかりません</p>
-					<Link
-						href={create.url({
-							query: { race_date: selectedDate || undefined },
-						})}
-					>
-						レース情報入力
-					</Link>
+					<Link href={createRaceUrl}>レース情報入力</Link>
 				</div>
 			) : (
 				<ScrollableTable>

--- a/source/resources/js/features/raceList/presentational/RaceList/index.tsx
+++ b/source/resources/js/features/raceList/presentational/RaceList/index.tsx
@@ -19,7 +19,13 @@ const RaceList = ({
 		<div className="flex flex-col gap-4 p-4">
 			<div className="flex items-center justify-between">
 				<h1 className="text-xl font-semibold">レース一覧</h1>
-				<Link href={create.url()}>レース情報入力</Link>
+				<Link
+					href={create.url({
+						query: { race_date: selectedDate || undefined },
+					})}
+				>
+					レース情報入力
+				</Link>
 			</div>
 
 			<div className="flex flex-wrap gap-4">
@@ -62,7 +68,13 @@ const RaceList = ({
 			{races.length === 0 ? (
 				<div className="flex flex-col items-center justify-center gap-4 py-16 text-muted-foreground">
 					<p>レースが見つかりません</p>
-					<Link href={create.url()}>レース情報入力</Link>
+					<Link
+						href={create.url({
+							query: { race_date: selectedDate || undefined },
+						})}
+					>
+						レース情報入力
+					</Link>
 				</div>
 			) : (
 				<ScrollableTable>

--- a/source/tests/Feature/Races/RaceCreateTest.php
+++ b/source/tests/Feature/Races/RaceCreateTest.php
@@ -65,3 +65,19 @@ test('session last_race_date is used when race_date query parameter is absent', 
         ->where('last_race_date', '2026-01-01')
     );
 });
+
+test('invalid race_date query parameter is ignored and falls back to session last_race_date', function () {
+    // Arrange
+    $user = User::factory()->create();
+
+    // Act
+    $response = $this->actingAs($user)
+        ->withSession(['last_race_date' => '2026-01-01'])
+        ->get(route('races.create', ['race_date' => 'invalid-date']));
+
+    // Assert
+    $response->assertOk();
+    $response->assertInertia(fn (Assert $page) => $page
+        ->where('last_race_date', '2026-01-01')
+    );
+});

--- a/source/tests/Feature/Races/RaceCreateTest.php
+++ b/source/tests/Feature/Races/RaceCreateTest.php
@@ -33,3 +33,35 @@ test('authenticated user can access race create page with venues prop', function
         ->has('venues', 2)
     );
 });
+
+test('race_date query parameter takes precedence over session last_race_date', function () {
+    // Arrange
+    $user = User::factory()->create();
+
+    // Act
+    $response = $this->actingAs($user)
+        ->withSession(['last_race_date' => '2026-01-01'])
+        ->get(route('races.create', ['race_date' => '2026-05-01']));
+
+    // Assert
+    $response->assertOk();
+    $response->assertInertia(fn (Assert $page) => $page
+        ->where('last_race_date', '2026-05-01')
+    );
+});
+
+test('session last_race_date is used when race_date query parameter is absent', function () {
+    // Arrange
+    $user = User::factory()->create();
+
+    // Act
+    $response = $this->actingAs($user)
+        ->withSession(['last_race_date' => '2026-01-01'])
+        ->get(route('races.create'));
+
+    // Assert
+    $response->assertOk();
+    $response->assertInertia(fn (Assert $page) => $page
+        ->where('last_race_date', '2026-01-01')
+    );
+});


### PR DESCRIPTION
## やったこと

- レース一覧の「レース情報入力」リンクに `race_date` クエリパラメータを付与するよう変更
- `RaceController::create` で `race_date` クエリパラメータをセッションの `last_race_date` より優先して使用するよう変更

## 結果

<\!-- スクリーンショット・動画を添付する -->

## 動作確認済み

- [ ] レース一覧で日付を選択した状態で「レース情報入力」をクリックすると、その日付がレース作成画面のデフォルト値として反映される