### PR TITLE
[minor] 枠連が非発売のレースでもレース結果を登録できるようにする

### DIFF
--- a/source/app/UseCases/RaceResult/StoreAction.php
+++ b/source/app/UseCases/RaceResult/StoreAction.php
@@ -43,9 +43,13 @@ class StoreAction
     /** 順序を保持する券種（着順どおり保存） */
     private const ORDERED_TYPES = ['umatan', 'sanrentan'];
 
-    /** 全8券種 */
+    /**
+     * 必須券種（枠連は任意のため含めない）。
+     * 枠連は8頭以下で同一枠に2頭以上いない場合に非発売となるため、
+     * JRA券種のうち頭数起因で非発売となり得る唯一の券種である。
+     */
     private const REQUIRED_TYPES = [
-        'tansho', 'fukusho', 'wakuren', 'wide',
+        'tansho', 'fukusho', 'wide',
         'umaren', 'umatan', 'sanrenpuku', 'sanrentan',
     ];
 
@@ -75,7 +79,7 @@ class StoreAction
             throw new ParseException($e->getMessage(), 'text');
         }
 
-        $ticketTypeIds = TicketType::whereIn('name', self::REQUIRED_TYPES)
+        $ticketTypeIds = TicketType::whereIn('name', array_values(self::TICKET_TYPE_MAP))
             ->pluck('id', 'name')
             ->all();
 
@@ -283,7 +287,7 @@ class StoreAction
     }
 
     /**
-     * パース結果に全8券種が揃っていることを検証する。
+     * パース結果に必須券種（枠連を除く7券種）が揃っていることを検証する。
      *
      * @param  array<int, array{ticket_type: string, horse_numbers: array<int, int>, amount: int, popularity: int}>  $entries
      *

--- a/source/docs/specs/openapi.yaml
+++ b/source/docs/specs/openapi.yaml
@@ -7,6 +7,15 @@ paths:
   /races/{uid}/result:
     post:
       summary: レース結果登録
+      description: |
+        払戻データ（payouts）には以下の券種を含める必要がある:
+        - 必須: tansho（単勝）, fukusho（複勝）, wide（ワイド）, umaren（馬連）, umatan（馬単）, sanrenpuku（3連複）, sanrentan（3連単）
+        - 任意: wakuren（枠連） — 出走頭数が少ないレースなど、JRAで枠連が発売されない場合は省略してよい
+
+        補足: フロントエンドからは JRA 公式サイトの払戻情報を貼り付けたテキストを送信する。
+        枠連が非発売のレースでは、貼り付けテキストに「枠連」セクションヘッダ行は存在するが、その下に
+        データ行が一切なく、次のセクション（ワイド）ヘッダが続く形になる。この場合 wakuren を含まない
+        payouts を生成する。
       operationId: storeRaceResult
       tags:
         - RaceResult

--- a/source/tests/Feature/Races/RaceResultTest.php
+++ b/source/tests/Feature/Races/RaceResultTest.php
@@ -65,6 +65,29 @@ $jraSampleText = implode("\n", [
     "3-6-11\t8,820円\t16番人気",
 ]);
 
+// 枠連のみヘッダー行があってデータ行が無いJRAフォーマット（枠連が非発売だったレースを想定）
+$jraSampleTextWithoutWakuren = implode("\n", [
+    "単勝\t",
+    "3\t610円\t2番人気",
+    "複勝\t",
+    "3\t170円\t2番人気",
+    "6\t110円\t1番人気",
+    "11\t170円\t3番人気",
+    "枠連\t",
+    "ワイド\t",
+    "3-6\t330円\t1番人気",
+    "3-11\t710円\t8番人気",
+    "6-11\t340円\t2番人気",
+    "馬連\t",
+    "3-6\t700円\t1番人気",
+    "馬単\t",
+    "3-6\t1,730円\t4番人気",
+    "3連複\t",
+    "3-6-11\t1,550円\t2番人気",
+    "3連単\t",
+    "3-6-11\t8,820円\t16番人気",
+]);
+
 /**
  * @return array{venueId: int, now: CarbonInterface}
  */
@@ -414,8 +437,10 @@ test('invalid format text returns error and nothing is stored', function () {
     expect(DB::table('race_payouts')->where('race_id', $raceId)->count())->toBe(0);
 });
 
-test('missing ticket types in text returns error and nothing is stored', function () {
+test('missing required ticket types in text returns error and nothing is stored', function () {
     // Arrange
+    // 単勝・複勝のみで、必須券種（枠連を除く6券種のうち wakuren 以外の5券種: wide, umaren, umatan, sanrenpuku, sanrentan）が欠落している。
+    // 枠連は任意券種なので欠落してもエラーにならないが、それ以外の必須券種が欠落するとエラーになることを保証する。
     $user = User::factory()->create();
     ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
     ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
@@ -451,6 +476,27 @@ test('JRA format payout text (ticket type on separate header line) is stored cor
     // Assert
     $response->assertRedirect(route('tickets.index'));
     expect(DB::table('race_payouts')->where('race_id', $raceId)->count())->toBe(12);
+});
+
+test('JRA format payout text without wakuren data (only header) is stored correctly', function () use ($jraSampleTextWithoutWakuren, $resultSampleText) {
+    // Arrange
+    $user = User::factory()->create();
+    ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();
+    ['raceId' => $raceId, 'raceUid' => $raceUid] = createRaceWithUid($venueId, $now);
+
+    // Act
+    $response = $this->actingAs($user)->post(route('races.result.store', ['uid' => $raceUid]), [
+        'result_text' => $resultSampleText, 'text' => $jraSampleTextWithoutWakuren,
+    ]);
+
+    // Assert
+    $response->assertRedirect(route('tickets.index'));
+    expect(DB::table('race_payouts')->where('race_id', $raceId)->count())->toBe(11);
+    $wakurenTicketTypeId = DB::table('ticket_types')->where('name', 'wakuren')->value('id');
+    expect(DB::table('race_payouts')
+        ->where('race_id', $raceId)
+        ->where('ticket_type_id', $wakurenTicketTypeId)
+        ->count())->toBe(0);
 });
 
 test('unauthenticated user is redirected to login page when posting race result', function () {

--- a/source/tests/Feature/Races/RaceResultTest.php
+++ b/source/tests/Feature/Races/RaceResultTest.php
@@ -439,7 +439,7 @@ test('invalid format text returns error and nothing is stored', function () {
 
 test('missing required ticket types in text returns error and nothing is stored', function () {
     // Arrange
-    // 単勝・複勝のみで、必須券種（枠連を除く6券種のうち wakuren 以外の5券種: wide, umaren, umatan, sanrenpuku, sanrentan）が欠落している。
+    // tansho・fukusho のみ含み、必須7券種のうち wide, umaren, umatan, sanrenpuku, sanrentan が欠落している。
     // 枠連は任意券種なので欠落してもエラーにならないが、それ以外の必須券種が欠落するとエラーになることを保証する。
     $user = User::factory()->create();
     ['venueId' => $venueId, 'now' => $now] = createRaceResultMasterData();


### PR DESCRIPTION
## やったこと

- `StoreAction` の `REQUIRED_TYPES` から `wakuren`（枠連）を除外し、枠連を任意券種として扱うよう変更
- 枠連が非発売のレースで JRA 公式サイトからコピーした払戻テキスト（枠連ヘッダ行のみ・データ行なし）を正常受理できるようにした
- `TicketType` のルックアップを全8券種（`TICKET_TYPE_MAP`）ベースに変更し、枠連ありの既存形式も引き続き正常動作することを保証
- `docs/specs/openapi.yaml` に必須/任意の分類と枠連非発売時のテキスト形式を追記
- テスト: 既存テスト `missing ticket types...` をリネーム・コメント追加、新規テスト（枠連ヘッダのみケース）を追加

## 結果

テストで確認済み（スクリーンショットなし）

## 動作確認済み

- [x] 新規テスト `JRA format payout text without wakuren data (only header) is stored correctly` pass（枠連レコード0件、他11件保存）
- [x] 枠連を含む既存 JRA 形式テストも引き続き pass（12件保存）
- [x] 必須券種が欠落するとエラーになることを既存テストで確認