### PR TITLE
[patch] バックエンド設計ドキュメントを実コードに整合させる

### DIFF
--- a/docs/architecture/backend/directory-structure.md
+++ b/docs/architecture/backend/directory-structure.md
@@ -16,6 +16,7 @@
 │   │       └── FeatureName/    # 例: Post/, User/
 │   ├── Models/                 # Eloquent モデル（DBテーブルの操作を定義）
 │   ├── Providers/              # サービスプロバイダ
+│   ├── Services/               # 複数 UseCase で再利用するロジック（パーサ・外部入力解析等）
 │   └── UseCases/               # ビジネスロジック（1アクション1クラス）
 │       └── FeatureName/        # 例: Post/, User/
 │           ├── StoreAction.php
@@ -40,6 +41,7 @@
 | `Http/Controllers` | HTTPリクエストの受け取りと `Inertia::render()` の呼び出しのみ。ビジネスロジックは持たない |
 | `Http/Requests` | バリデーションと認可（`authorize()`）を一本化 |
 | `UseCases` | ビジネスロジックとドメイン検証をカプセル化。1アクション1クラス |
+| `Services` | 複数 UseCase で再利用するロジック（パーサ・外部入力解析等） |
 | `Models` | Eloquent によるDBアクセス。Repository パターンは導入しない |
 | `Exceptions` | HTTP非依存のドメイン例外。コントローラ側で HTTP レスポンスに変換する |
 
@@ -79,6 +81,20 @@ class PostController extends Controller
             'posts' => Post::all(),
         ]);
     }
+}
+```
+
+### UseCase の合成（UseCase間DI）
+
+UseCase は他の UseCase をコンストラクタ DI で受け取って合成してよい。
+
+```php
+// app/UseCases/TicketPurchase/StoreAction.php
+class StoreAction
+{
+    public function __construct(
+        private readonly CalculatePayoutAmountAction $calculatePayoutAmountAction,
+    ) {}
 }
 ```
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -54,3 +54,5 @@ Laravel Fortify を使用。認証状態は Inertia の shared data を通じて
 ## フロントエンド↔バックエンドのAPI連携方針
 
 Inertia.js を通じてデータを受け渡す。REST API は原則設けず、フォーム送信・ページ遷移はすべて Inertia の `router` を使用する。
+
+ただし、クライアントサイドの自動保存など細かい更新では JSON API（`/api` プレフィックス）を許容する（例: `routes/web.php` の `/api/races/{race:uid}/mark-columns` 系ルート）。


### PR DESCRIPTION
## やったこと

- `docs/architecture/backend/directory-structure.md` に `app/Services/` ディレクトリを追加し、複数 UseCase で再利用するロジックの置き場として説明を追記
- 同ファイルに「UseCase の合成（UseCase間DI）」セクションを追加し、UseCase が他の UseCase をコンストラクタ DI で受け取れることを明記（実例: `TicketPurchase/StoreAction` が `CalculatePayoutAmountAction` を DI）
- `docs/architecture/overview.md` のAPI連携方針に、クライアントサイドの自動保存等では JSON API（`/api` プレフィックス）を許容する旨を追記

## 結果

ドキュメントのみの変更のためスクリーンショットなし。

## 動作確認済み

- [ ] ドキュメントの記載内容が実コードと一致していることを確認