### PR TITLE
[patch] ドメイン定数を Constants/Enum に集約

### DIFF
--- a/source/app/Constants/Money.php
+++ b/source/app/Constants/Money.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Constants;
+
+final class Money
+{
+    /**
+     * JRA が公表する払戻金額の基準購入額（100円券あたり）。
+     *
+     * @see resources/js/constants/money.ts JRA_PAYOUT_BASE_STAKE と同期させること
+     */
+    public const JRA_PAYOUT_BASE_STAKE = 100;
+
+    private function __construct() {}
+}

--- a/source/app/Enums/TicketTypeName.php
+++ b/source/app/Enums/TicketTypeName.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * 馬券種別の name (ticket_types.name と同値)。
+ *
+ * `tanpuku` は本アプリ独自の概念（単勝+複勝の同時購入）であり、
+ * JRA 公式券種ではないため `App\UseCases\RaceResult\StoreAction::TICKET_TYPE_MAP` には含まれない。
+ *
+ * @see resources/js/constants/ticketType.ts と同期させること
+ */
+enum TicketTypeName: string
+{
+    case Tansho = 'tansho';
+    case Fukusho = 'fukusho';
+    case Wakuren = 'wakuren';
+    case Umaren = 'umaren';
+    case Umatan = 'umatan';
+    case Wide = 'wide';
+    case Sanrenpuku = 'sanrenpuku';
+    case Sanrentan = 'sanrentan';
+    case Tanpuku = 'tanpuku';
+
+    /**
+     * 着順を保持する券種か。
+     */
+    public function isOrdered(): bool
+    {
+        return match ($this) {
+            self::Umatan, self::Sanrentan => true,
+            default => false,
+        };
+    }
+
+    /**
+     * 照合対象となる馬番の数。
+     */
+    public function horseCount(): int
+    {
+        return match ($this) {
+            self::Tansho, self::Fukusho => 1,
+            self::Sanrenpuku, self::Sanrentan => 3,
+            self::Wakuren, self::Umaren, self::Umatan, self::Wide, self::Tanpuku => 2,
+        };
+    }
+}

--- a/source/app/Http/Requests/TicketPurchase/StoreTicketPurchaseRequest.php
+++ b/source/app/Http/Requests/TicketPurchase/StoreTicketPurchaseRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\TicketPurchase;
 
+use App\Constants\Money;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -29,7 +30,7 @@ class StoreTicketPurchaseRequest extends FormRequest
             'ticket_type' => ['required', 'string', 'exists:ticket_types,name'],
             'buy_type' => ['required', 'string', 'exists:buy_types,name'],
             'selections' => ['required', 'array'],
-            'unit_stake' => ['nullable', 'integer', 'min:100'],
+            'unit_stake' => ['nullable', 'integer', 'min:'.Money::JRA_PAYOUT_BASE_STAKE],
         ];
     }
 }

--- a/source/app/UseCases/RaceResult/StoreAction.php
+++ b/source/app/UseCases/RaceResult/StoreAction.php
@@ -2,6 +2,7 @@
 
 namespace App\UseCases\RaceResult;
 
+use App\Enums\TicketTypeName;
 use App\Exceptions\RaceResult\ParseException;
 use App\Models\Horse;
 use App\Models\Jockey;
@@ -28,20 +29,17 @@ use Illuminate\Support\Facades\DB;
  */
 class StoreAction
 {
-    /** 券種ラベル → ticket_types.name の対応 */
+    /** 券種ラベル → ticket_types.name の対応（tanpuku は本アプリ独自で JRA テキストには現れない） */
     private const TICKET_TYPE_MAP = [
-        '単勝' => 'tansho',
-        '複勝' => 'fukusho',
-        '枠連' => 'wakuren',
-        'ワイド' => 'wide',
-        '馬連' => 'umaren',
-        '馬単' => 'umatan',
-        '3連複' => 'sanrenpuku',
-        '3連単' => 'sanrentan',
+        '単勝' => TicketTypeName::Tansho->value,
+        '複勝' => TicketTypeName::Fukusho->value,
+        '枠連' => TicketTypeName::Wakuren->value,
+        'ワイド' => TicketTypeName::Wide->value,
+        '馬連' => TicketTypeName::Umaren->value,
+        '馬単' => TicketTypeName::Umatan->value,
+        '3連複' => TicketTypeName::Sanrenpuku->value,
+        '3連単' => TicketTypeName::Sanrentan->value,
     ];
-
-    /** 順序を保持する券種（着順どおり保存） */
-    private const ORDERED_TYPES = ['umatan', 'sanrentan'];
 
     /**
      * 必須券種（枠連は任意のため含めない）。
@@ -49,8 +47,13 @@ class StoreAction
      * JRA券種のうち頭数起因で非発売となり得る唯一の券種である。
      */
     private const REQUIRED_TYPES = [
-        'tansho', 'fukusho', 'wide',
-        'umaren', 'umatan', 'sanrenpuku', 'sanrentan',
+        TicketTypeName::Tansho->value,
+        TicketTypeName::Fukusho->value,
+        TicketTypeName::Wide->value,
+        TicketTypeName::Umaren->value,
+        TicketTypeName::Umatan->value,
+        TicketTypeName::Sanrenpuku->value,
+        TicketTypeName::Sanrentan->value,
     ];
 
     public function __construct(
@@ -103,7 +106,7 @@ class StoreAction
                     'popularity' => $entry['popularity'],
                 ]);
 
-                $isOrdered = in_array($entry['ticket_type'], self::ORDERED_TYPES, true);
+                $isOrdered = TicketTypeName::from($entry['ticket_type'])->isOrdered();
                 $horseNumbers = $entry['horse_numbers'];
 
                 if (! $isOrdered) {

--- a/source/app/UseCases/TicketPurchase/CalculatePayoutAmountAction.php
+++ b/source/app/UseCases/TicketPurchase/CalculatePayoutAmountAction.php
@@ -2,6 +2,8 @@
 
 namespace App\UseCases\TicketPurchase;
 
+use App\Constants\Money;
+use App\Enums\TicketTypeName;
 use App\Models\RacePayout;
 use App\Models\TicketPurchase;
 use Illuminate\Database\Eloquent\Collection;
@@ -14,11 +16,6 @@ use Illuminate\Database\Eloquent\Collection;
  */
 class CalculatePayoutAmountAction
 {
-    /**
-     * JRAが公表する払戻金額の基準購入額（100円券あたり）。
-     */
-    private const JRA_PAYOUT_BASE_STAKE = 100;
-
     public function __construct(private readonly ExpandSelectionsAction $expandSelections) {}
 
     /**
@@ -36,7 +33,7 @@ class CalculatePayoutAmountAction
         $ticketTypeName = $purchase->ticketType->name;
         $buyTypeName = $purchase->buyType->name;
         $selections = $purchase->selections;
-        $isOrdered = in_array($ticketTypeName, ['umatan', 'sanrentan'], true);
+        $isOrdered = TicketTypeName::from($ticketTypeName)->isOrdered();
 
         $combinations = $this->expandSelections->execute($ticketTypeName, $buyTypeName, $selections);
 
@@ -81,7 +78,7 @@ class CalculatePayoutAmountAction
             return null;
         }
 
-        return (int) ($totalPayout * $purchase->unit_stake / self::JRA_PAYOUT_BASE_STAKE);
+        return (int) ($totalPayout * $purchase->unit_stake / Money::JRA_PAYOUT_BASE_STAKE);
     }
 
     /**

--- a/source/app/UseCases/TicketPurchase/ExpandSelectionsAction.php
+++ b/source/app/UseCases/TicketPurchase/ExpandSelectionsAction.php
@@ -2,6 +2,8 @@
 
 namespace App\UseCases\TicketPurchase;
 
+use App\Enums\TicketTypeName;
+
 /**
  * TicketPurchase の selections を、券種・買い方に応じた有効な組み合わせ配列に展開する。
  *
@@ -10,22 +12,6 @@ namespace App\UseCases\TicketPurchase;
  */
 class ExpandSelectionsAction
 {
-    /** 着順を保持する券種 */
-    private const ORDERED_TYPES = ['umatan', 'sanrentan'];
-
-    /** 券種ごとの照合対象馬番数 */
-    private const TICKET_TYPE_HORSE_COUNT = [
-        'tansho' => 1,
-        'fukusho' => 1,
-        'wakuren' => 2,
-        'umaren' => 2,
-        'umatan' => 2,
-        'wide' => 2,
-        'sanrenpuku' => 3,
-        'sanrentan' => 3,
-        'tanpuku' => 2,
-    ];
-
     /**
      * 券種名・買い方名・selections から有効な組み合わせの配列を返す。
      * 未対応の券種・組み合わせが成立しない場合は空配列を返す。
@@ -35,20 +21,21 @@ class ExpandSelectionsAction
      */
     public function execute(string $ticketTypeName, string $buyTypeName, ?array $selections): array
     {
-        $horseCount = self::TICKET_TYPE_HORSE_COUNT[$ticketTypeName] ?? null;
-        if ($horseCount === null) {
+        $ticketType = TicketTypeName::tryFrom($ticketTypeName);
+        if ($ticketType === null) {
             return [];
         }
+        $horseCount = $ticketType->horseCount();
 
         // tanpuku は1馬選択で単勝+複勝の2点同時購入として扱う（normalize による重複排除を避けるため、展開ロジックを分岐させる）
-        if ($ticketTypeName === 'tanpuku') {
+        if ($ticketType === TicketTypeName::Tanpuku) {
             $horses = $this->extractIntList(($selections ?? [])['horses'] ?? []);
             $singles = array_map(static fn (int $h): array => [$h], $horses);
 
             return array_merge($singles, $singles);
         }
 
-        $isOrdered = in_array($ticketTypeName, self::ORDERED_TYPES, true);
+        $isOrdered = $ticketType->isOrdered();
         $selections = $selections ?? [];
 
         $combinations = match ($buyTypeName) {

--- a/source/database/seeders/TicketTypeSeeder.php
+++ b/source/database/seeders/TicketTypeSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Enums\TicketTypeName;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
@@ -14,15 +15,15 @@ class TicketTypeSeeder extends Seeder
     {
         $now = now();
         $types = [
-            ['name' => 'tansho', 'label' => '単勝', 'sort_order' => 1, 'created_at' => $now, 'updated_at' => $now],
-            ['name' => 'fukusho', 'label' => '複勝', 'sort_order' => 2, 'created_at' => $now, 'updated_at' => $now],
-            ['name' => 'wakuren', 'label' => '枠連', 'sort_order' => 3, 'created_at' => $now, 'updated_at' => $now],
-            ['name' => 'umaren', 'label' => '馬連', 'sort_order' => 4, 'created_at' => $now, 'updated_at' => $now],
-            ['name' => 'umatan', 'label' => '馬単', 'sort_order' => 5, 'created_at' => $now, 'updated_at' => $now],
-            ['name' => 'wide', 'label' => 'ワイド', 'sort_order' => 6, 'created_at' => $now, 'updated_at' => $now],
-            ['name' => 'sanrenpuku', 'label' => '三連複', 'sort_order' => 7, 'created_at' => $now, 'updated_at' => $now],
-            ['name' => 'sanrentan', 'label' => '三連単', 'sort_order' => 8, 'created_at' => $now, 'updated_at' => $now],
-            ['name' => 'tanpuku', 'label' => '単複', 'sort_order' => 9, 'created_at' => $now, 'updated_at' => $now],
+            ['name' => TicketTypeName::Tansho->value, 'label' => '単勝', 'sort_order' => 1, 'created_at' => $now, 'updated_at' => $now],
+            ['name' => TicketTypeName::Fukusho->value, 'label' => '複勝', 'sort_order' => 2, 'created_at' => $now, 'updated_at' => $now],
+            ['name' => TicketTypeName::Wakuren->value, 'label' => '枠連', 'sort_order' => 3, 'created_at' => $now, 'updated_at' => $now],
+            ['name' => TicketTypeName::Umaren->value, 'label' => '馬連', 'sort_order' => 4, 'created_at' => $now, 'updated_at' => $now],
+            ['name' => TicketTypeName::Umatan->value, 'label' => '馬単', 'sort_order' => 5, 'created_at' => $now, 'updated_at' => $now],
+            ['name' => TicketTypeName::Wide->value, 'label' => 'ワイド', 'sort_order' => 6, 'created_at' => $now, 'updated_at' => $now],
+            ['name' => TicketTypeName::Sanrenpuku->value, 'label' => '三連複', 'sort_order' => 7, 'created_at' => $now, 'updated_at' => $now],
+            ['name' => TicketTypeName::Sanrentan->value, 'label' => '三連単', 'sort_order' => 8, 'created_at' => $now, 'updated_at' => $now],
+            ['name' => TicketTypeName::Tanpuku->value, 'label' => '単複', 'sort_order' => 9, 'created_at' => $now, 'updated_at' => $now],
         ];
 
         DB::table('ticket_types')->insert($types);

--- a/source/resources/js/constants/money.ts
+++ b/source/resources/js/constants/money.ts
@@ -1,0 +1,6 @@
+/**
+ * JRA が公表する払戻金額の基準購入額（100円券あたり）。
+ *
+ * @see app/Constants/Money.php Money::JRA_PAYOUT_BASE_STAKE と同期させること
+ */
+export const JRA_PAYOUT_BASE_STAKE = 100;

--- a/source/resources/js/constants/ticketType.ts
+++ b/source/resources/js/constants/ticketType.ts
@@ -1,0 +1,36 @@
+/**
+ * 馬券種別の name (ticket_types.name と同値)。
+ *
+ * 並び順は `database/seeders/TicketTypeSeeder.php` の `sort_order` と一致させる。
+ * `tanpuku` は本アプリ独自の概念（単勝+複勝の同時購入）であり、JRA 公式券種ではない。
+ *
+ * @see app/Enums/TicketTypeName.php TicketTypeName と同期させること
+ */
+export const TICKET_TYPE_NAMES = [
+	"tansho",
+	"fukusho",
+	"wakuren",
+	"umaren",
+	"umatan",
+	"wide",
+	"sanrenpuku",
+	"sanrentan",
+	"tanpuku",
+] as const;
+
+export type TicketTypeName = (typeof TICKET_TYPE_NAMES)[number];
+
+export const TICKET_TYPE_LABELS: Record<TicketTypeName, string> = {
+	tansho: "単勝",
+	fukusho: "複勝",
+	wakuren: "枠連",
+	umaren: "馬連",
+	umatan: "馬単",
+	wide: "ワイド",
+	sanrenpuku: "三連複",
+	sanrentan: "三連単",
+	tanpuku: "単複",
+};
+
+/** 着順を保持する券種 */
+export const ORDERED_TICKET_TYPE_NAMES = ["umatan", "sanrentan"] as const;

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/constants.ts
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/constants.ts
@@ -1,3 +1,5 @@
+import { TICKET_TYPE_LABELS, TICKET_TYPE_NAMES } from "@/constants/ticketType";
+
 export const VENUES = [
 	"東京",
 	"中山",
@@ -11,18 +13,19 @@ export const VENUES = [
 	"中京",
 ] as const;
 
-export const TICKET_TYPES = [
-	{ id: "tansho", label: "単勝" },
-	{ id: "fukusho", label: "複勝" },
-	{ id: "wakuren", label: "枠連" },
-	{ id: "umaren", label: "馬連" },
-	{ id: "umatan", label: "馬単" },
-	{ id: "wide", label: "ワイド" },
-	{ id: "sanrenpuku", label: "三連複" },
-	{ id: "sanrentan", label: "三連単" },
-] as const;
+/** UI 表示対象の券種 (tanpuku は本アプリ独自概念のため UI からは選択させない) */
+export type TicketTypeId = Exclude<
+	(typeof TICKET_TYPE_NAMES)[number],
+	"tanpuku"
+>;
 
-export type TicketTypeId = (typeof TICKET_TYPES)[number]["id"];
+export const TICKET_TYPES: ReadonlyArray<{ id: TicketTypeId; label: string }> =
+	TICKET_TYPE_NAMES.filter((id): id is TicketTypeId => id !== "tanpuku").map(
+		(id) => ({
+			id,
+			label: TICKET_TYPE_LABELS[id],
+		}),
+	);
 
 export const BUY_TYPE_MAP: Record<
 	TicketTypeId,

--- a/source/resources/js/features/ticket/presentational/TicketPurchaseForm/index.tsx
+++ b/source/resources/js/features/ticket/presentational/TicketPurchaseForm/index.tsx
@@ -1,6 +1,7 @@
 import BackButton from "@/components/presentational/BackButton";
 import { Button } from "@/components/shadcn/ui/button";
 import { Input } from "@/components/shadcn/ui/input";
+import { JRA_PAYOUT_BASE_STAKE } from "@/constants/money";
 import { HorseSelectionSection } from "./HorseSelectionSection";
 import { RaceInfoSection } from "./RaceInfoSection";
 import { Section } from "./Section";
@@ -75,20 +76,27 @@ const TicketPurchaseForm = ({
 						variant="outline"
 						size="icon"
 						aria-label="100円減らす"
-						onClick={() => onUnitStakeChange(Math.max(100, unitStake - 100))}
+						onClick={() =>
+							onUnitStakeChange(
+								Math.max(
+									JRA_PAYOUT_BASE_STAKE,
+									unitStake - JRA_PAYOUT_BASE_STAKE,
+								),
+							)
+						}
 					>
 						−
 					</Button>
 					<Input
 						type="number"
-						min={100}
-						step={100}
+						min={JRA_PAYOUT_BASE_STAKE}
+						step={JRA_PAYOUT_BASE_STAKE}
 						value={unitStake}
 						className="w-28 text-center"
 						aria-label="購入金額（円）"
 						onChange={(e) => {
 							const n = Number.parseInt(e.target.value, 10);
-							if (n >= 100) onUnitStakeChange(n);
+							if (n >= JRA_PAYOUT_BASE_STAKE) onUnitStakeChange(n);
 						}}
 					/>
 					<span className="text-sm text-muted-foreground">円</span>
@@ -97,12 +105,12 @@ const TicketPurchaseForm = ({
 						variant="outline"
 						size="icon"
 						aria-label="100円増やす"
-						onClick={() => onUnitStakeChange(unitStake + 100)}
+						onClick={() => onUnitStakeChange(unitStake + JRA_PAYOUT_BASE_STAKE)}
 					>
 						＋
 					</Button>
 					<div className="ml-4 flex gap-1.5">
-						{[100, 500, 1000].map((preset) => (
+						{[JRA_PAYOUT_BASE_STAKE, 500, 1000].map((preset) => (
 							<Button
 								key={preset}
 								type="button"

--- a/source/resources/js/pages/tickets/new.tsx
+++ b/source/resources/js/pages/tickets/new.tsx
@@ -1,5 +1,6 @@
-import { Head, usePage } from "@inertiajs/react";
+import { JRA_PAYOUT_BASE_STAKE } from "@/constants/money";
 import TicketPurchaseFormContainer from "@/features/ticket/containers/TicketPurchaseFormContainer";
+import { Head, usePage } from "@inertiajs/react";
 
 type TicketsNewProps = {
 	lastVenue: string;
@@ -23,7 +24,7 @@ const TicketsNew = () => {
 				initialAxisCount={1}
 				initialNagashiDirection={1}
 				initialHorses={{}}
-				initialUnitStake={100}
+				initialUnitStake={JRA_PAYOUT_BASE_STAKE}
 			/>
 		</>
 	);


### PR DESCRIPTION
Closes #223

## やったこと

- `app/Enums/TicketTypeName.php` を新設（PHP Backed Enum、9 case + `isOrdered()` / `horseCount()` メソッド）
- `app/Constants/Money.php` を新設（`JRA_PAYOUT_BASE_STAKE = 100` の集約）
- TS 側に `resources/js/constants/{money.ts,ticketType.ts}` を新設し、PHP との手動同期を `@see` コメントで明記
- 重複・分散していた以下の参照を集約定数/Enum 参照に置換
  - `ORDERED_TYPES = ['umatan', 'sanrentan']` (3 箇所重複) → `TicketTypeName::isOrdered()`
  - `JRA_PAYOUT_BASE_STAKE = 100` の private const と `'min:100'` バリデーション → `Money::JRA_PAYOUT_BASE_STAKE`
  - `ExpandSelectionsAction::TICKET_TYPE_HORSE_COUNT` → `TicketTypeName::horseCount()`
  - `TicketTypeSeeder` の `name` リテラル → enum value 参照（seeder と enum の値ズレを根絶）
  - フロントの `100` ハードコード（min/step/計算式/preset 配列・初期値）→ `JRA_PAYOUT_BASE_STAKE`
  - `TicketPurchaseForm/constants.ts` の `TICKET_TYPES` を `TICKET_TYPE_NAMES` + `TICKET_TYPE_LABELS` から導出する形に変更
- 外部仕様（API・UI 挙動・DB スキーマ）は不変

## 設計判断

- **Enum vs class const**: 馬券種別だけ Backed Enum、金額系は class const とする中庸案を採用。enum 化により `match` の網羅性チェックと振る舞い集約（`isOrdered`, `horseCount`）の旨みを得つつ、整数 1 個の `JRA_PAYOUT_BASE_STAKE` は class const のままシンプルに保つ
- **PHP↔TS 共有**: 自動生成は導入せず、`@see` コメントによる手動同期。将来 `artisan generate:ts-constants` のような自動化への移行余地は残す（フォローアップ候補）
- **`StoreAction::TICKET_TYPE_MAP` の日本語キーは残置**: JRA 払戻テキストパース用のビジネスルールであり、enum の責務外
- **UI 用 `TicketTypeId` は 8 種に絞る**: `BUY_TYPE_MAP` の型整合のため `Exclude<..., "tanpuku">` で派生型を作る（`tanpuku` は本アプリ独自概念で UI からは選択させない）
- **テスト新規追加なし**: 既存の `CalculatePayoutAmountActionTest` / `ExpandSelectionsActionTest` / `RaceResultTest` / `TicketPurchaseTest` / `TicketPurchaseForm.unit.test.tsx` が振る舞いを担保。enum の値そのものをテストするのはトートロジー

## 結果

スクリーンショット添付対象なし（コード品質向上目的のリファクタリングで UI 変更なし）。

## 動作確認済み

- [x] `vendor/bin/sail bin pint --dirty --format agent` パス
- [x] ローカルで PHP 構文チェック (`php -l`) 全ファイル OK
- [x] ローカルで `tsc --noEmit` 私の変更による新規エラーなし
- [x] ローカルで `biome check` パス
- [ ] `vendor/bin/sail artisan test --compact` （ローカルでは Vite manifest 未生成で別件失敗、CI で確認）
- [ ] 馬券登録画面の操作確認（金額入力 +/- ボタン、preset、登録）

## コミット構成

1. `64df2aa` 集約先ディレクトリと Enum/Constants の新設
2. `db79963` PHP 側の参照置換
3. `fe640e7` TS 側の参照置換

🤖 Generated with [Claude Code](https://claude.com/claude-code)