### PR TITLE
[patch] 払戻テキストのパース処理を RaceResultPayoutParser に切り出し

### DIFF
--- a/source/app/Services/RaceResultPayoutParser.php
+++ b/source/app/Services/RaceResultPayoutParser.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\TicketTypeName;
+
+/**
+ * JRA払い戻しテキストをパースし、券種ごとの払い戻し明細エントリを抽出する。
+ *
+ * テキストの各行はタブ区切りで「券種名\t馬番\t金額\t人気」の4列。
+ * 券種名が空の行は直前の券種の続き（複勝・ワイドなど複数行の券種）。
+ * 各行が独立したエントリとなる。
+ *
+ * @throws \InvalidArgumentException パースに失敗した場合
+ */
+class RaceResultPayoutParser
+{
+    /** 券種ラベル → ticket_types.name の対応（tanpuku は本アプリ独自で JRA テキストには現れない） */
+    public const TICKET_TYPE_MAP = [
+        '単勝' => TicketTypeName::Tansho->value,
+        '複勝' => TicketTypeName::Fukusho->value,
+        '枠連' => TicketTypeName::Wakuren->value,
+        'ワイド' => TicketTypeName::Wide->value,
+        '馬連' => TicketTypeName::Umaren->value,
+        '馬単' => TicketTypeName::Umatan->value,
+        '3連複' => TicketTypeName::Sanrenpuku->value,
+        '3連単' => TicketTypeName::Sanrentan->value,
+    ];
+
+    /**
+     * 必須券種（枠連は任意のため含めない）。
+     * 枠連は8頭以下で同一枠に2頭以上いない場合に非発売となるため、
+     * JRA券種のうち頭数起因で非発売となり得る唯一の券種である。
+     */
+    private const REQUIRED_TYPES = [
+        TicketTypeName::Tansho->value,
+        TicketTypeName::Fukusho->value,
+        TicketTypeName::Wide->value,
+        TicketTypeName::Umaren->value,
+        TicketTypeName::Umatan->value,
+        TicketTypeName::Sanrenpuku->value,
+        TicketTypeName::Sanrentan->value,
+    ];
+
+    /**
+     * JRA払い戻しテキストをパースし、各行を独立したエントリとして返す。
+     * 複勝・ワイドなど複数行の券種は、各行がそれぞれ独立した払い戻し明細となる。
+     *
+     * @return array<int, array{ticket_type: string, horse_numbers: array<int, int>, amount: int, popularity: int}>
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function parse(string $text): array
+    {
+        $trimmed = trim($text);
+        if ($trimmed === '') {
+            throw new \InvalidArgumentException('テキストが空です。');
+        }
+
+        $lines = preg_split('/\r?\n/', $trimmed);
+        if ($lines === false || $lines === []) {
+            throw new \InvalidArgumentException('テキストが空です。');
+        }
+
+        /** @var array<int, array{ticket_type: string, horse_numbers: array<int, int>, amount: int, popularity: int}> $entries */
+        $entries = [];
+        $currentTicketType = null;
+
+        foreach ($lines as $lineNumber => $line) {
+            $line = rtrim($line);
+            if ($line === '') {
+                continue;
+            }
+
+            $columns = explode("\t", $line);
+            $ticketLabel = trim($columns[0]);
+
+            // JRAコピペフォーマット: 券種名のみの行（例: "単勝"）
+            if (count($columns) === 1) {
+                if (! isset(self::TICKET_TYPE_MAP[$ticketLabel])) {
+                    throw new \InvalidArgumentException(
+                        sprintf('%d行目: データの形式が認識できません。', $lineNumber + 1)
+                    );
+                }
+                $currentTicketType = self::TICKET_TYPE_MAP[$ticketLabel];
+
+                continue;
+            }
+
+            // JRAコピペフォーマット: データ行（例: "3\t610円\t2番人気"）
+            if (count($columns) === 3 && ! isset(self::TICKET_TYPE_MAP[$ticketLabel])) {
+                $horseCol = $columns[0];
+                $amountCol = $columns[1];
+                $popularityCol = $columns[2];
+            }
+            // インライン / 継続フォーマット（例: "単勝\t3\t610円\t2番人気" or "\t6\t110円\t1番人気"）
+            elseif (count($columns) >= 4) {
+                if ($ticketLabel !== '') {
+                    if (! isset(self::TICKET_TYPE_MAP[$ticketLabel])) {
+                        throw new \InvalidArgumentException(
+                            sprintf('%d行目: 不明な券種「%s」です。', $lineNumber + 1, $ticketLabel)
+                        );
+                    }
+                    $currentTicketType = self::TICKET_TYPE_MAP[$ticketLabel];
+                }
+                $horseCol = $columns[1] ?? '';
+                $amountCol = $columns[2] ?? '';
+                $popularityCol = $columns[3] ?? '';
+            } else {
+                throw new \InvalidArgumentException(
+                    sprintf('%d行目: データの形式が認識できません。', $lineNumber + 1)
+                );
+            }
+
+            if ($currentTicketType === null) {
+                throw new \InvalidArgumentException(
+                    sprintf('%d行目: 券種名が特定できません。', $lineNumber + 1)
+                );
+            }
+
+            $entries[] = [
+                'ticket_type' => $currentTicketType,
+                'horse_numbers' => $this->parseHorseNumbers($horseCol, $lineNumber + 1),
+                'amount' => $this->parseAmount($amountCol, $lineNumber + 1),
+                'popularity' => $this->parsePopularity($popularityCol, $lineNumber + 1),
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * パース結果に必須券種（枠連を除く7券種）が揃っていることを検証する。
+     *
+     * @param  array<int, array{ticket_type: string, horse_numbers: array<int, int>, amount: int, popularity: int}>  $entries
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function validateAllTypesPresent(array $entries): void
+    {
+        $foundTypes = array_unique(array_column($entries, 'ticket_type'));
+        $missing = array_diff(self::REQUIRED_TYPES, $foundTypes);
+
+        if ($missing !== []) {
+            $missingLabels = [];
+            $labelMap = array_flip(self::TICKET_TYPE_MAP);
+            foreach ($missing as $name) {
+                $missingLabels[] = $labelMap[$name] ?? $name;
+            }
+
+            throw new \InvalidArgumentException(
+                sprintf('以下の券種が不足しています: %s', implode('、', $missingLabels))
+            );
+        }
+    }
+
+    /**
+     * @return array<int, int>
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function parseHorseNumbers(string $col, int $lineNumber): array
+    {
+        $col = trim($col);
+        if ($col === '') {
+            throw new \InvalidArgumentException(
+                sprintf('%d行目: 馬番が空です。', $lineNumber)
+            );
+        }
+
+        $parts = explode('-', $col);
+        $numbers = [];
+        foreach ($parts as $part) {
+            $part = trim($part);
+            if (! ctype_digit($part) || $part === '') {
+                throw new \InvalidArgumentException(
+                    sprintf('%d行目: 馬番「%s」が不正です。', $lineNumber, $col)
+                );
+            }
+            $numbers[] = (int) $part;
+        }
+
+        return $numbers;
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    private function parseAmount(string $col, int $lineNumber): int
+    {
+        $col = trim($col);
+        $cleaned = str_replace([',', '円'], '', $col);
+        if (! ctype_digit($cleaned) || $cleaned === '') {
+            throw new \InvalidArgumentException(
+                sprintf('%d行目: 金額「%s」が不正です。', $lineNumber, $col)
+            );
+        }
+
+        return (int) $cleaned;
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    private function parsePopularity(string $col, int $lineNumber): int
+    {
+        $col = trim($col);
+        $cleaned = str_replace('番人気', '', $col);
+        if (! ctype_digit($cleaned) || $cleaned === '') {
+            throw new \InvalidArgumentException(
+                sprintf('%d行目: 人気「%s」が不正です。', $lineNumber, $col)
+            );
+        }
+
+        return (int) $cleaned;
+    }
+}

--- a/source/app/Services/RaceResultPayoutParser.php
+++ b/source/app/Services/RaceResultPayoutParser.php
@@ -16,7 +16,7 @@ use App\Enums\TicketTypeName;
 class RaceResultPayoutParser
 {
     /** 券種ラベル → ticket_types.name の対応（tanpuku は本アプリ独自で JRA テキストには現れない） */
-    public const TICKET_TYPE_MAP = [
+    private const TICKET_TYPE_MAP = [
         '単勝' => TicketTypeName::Tansho->value,
         '複勝' => TicketTypeName::Fukusho->value,
         '枠連' => TicketTypeName::Wakuren->value,
@@ -172,7 +172,7 @@ class RaceResultPayoutParser
         $numbers = [];
         foreach ($parts as $part) {
             $part = trim($part);
-            if (! ctype_digit($part) || $part === '') {
+            if (! ctype_digit($part)) {
                 throw new \InvalidArgumentException(
                     sprintf('%d行目: 馬番「%s」が不正です。', $lineNumber, $col)
                 );
@@ -190,7 +190,7 @@ class RaceResultPayoutParser
     {
         $col = trim($col);
         $cleaned = str_replace([',', '円'], '', $col);
-        if (! ctype_digit($cleaned) || $cleaned === '') {
+        if (! ctype_digit($cleaned)) {
             throw new \InvalidArgumentException(
                 sprintf('%d行目: 金額「%s」が不正です。', $lineNumber, $col)
             );
@@ -206,7 +206,7 @@ class RaceResultPayoutParser
     {
         $col = trim($col);
         $cleaned = str_replace('番人気', '', $col);
-        if (! ctype_digit($cleaned) || $cleaned === '') {
+        if (! ctype_digit($cleaned)) {
             throw new \InvalidArgumentException(
                 sprintf('%d行目: 人気「%s」が不正です。', $lineNumber, $col)
             );

--- a/source/app/UseCases/RaceResult/StoreAction.php
+++ b/source/app/UseCases/RaceResult/StoreAction.php
@@ -56,7 +56,8 @@ class StoreAction
             throw new ParseException($e->getMessage(), 'text');
         }
 
-        $ticketTypeIds = TicketType::whereIn('name', array_values(RaceResultPayoutParser::TICKET_TYPE_MAP))
+        $ticketTypeNames = array_unique(array_column($entries, 'ticket_type'));
+        $ticketTypeIds = TicketType::whereIn('name', $ticketTypeNames)
             ->pluck('id', 'name')
             ->all();
 

--- a/source/app/UseCases/RaceResult/StoreAction.php
+++ b/source/app/UseCases/RaceResult/StoreAction.php
@@ -13,52 +13,26 @@ use App\Models\RaceResultHorse;
 use App\Models\TicketPurchase;
 use App\Models\TicketType;
 use App\Services\RaceResultHorseParser;
+use App\Services\RaceResultPayoutParser;
 use App\UseCases\TicketPurchase\CalculatePayoutAmountAction;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 
 /**
- * JRA払い戻しテキストをパースし、race_payouts / race_payout_horses に保存する。
+ * パース済みのレース結果テキストおよび払戻テキストから、
+ * race_result_horses / race_payouts / race_payout_horses を保存する。
  *
- * テキストの各行はタブ区切りで「券種名\t馬番\t金額\t人気」の4列。
- * 券種名が空の行は直前の券種の続き（複勝・ワイドなど複数行の券種）。
- * 各行が独立した race_payouts レコードとなり、
- * 行内の馬番は race_payout_horses に保存する。
+ * 払戻テキスト・着順テキストのパースは
+ * {@see RaceResultPayoutParser} / {@see RaceResultHorseParser} に委譲する。
  *
  * @throws \InvalidArgumentException パースに失敗した場合
  */
 class StoreAction
 {
-    /** 券種ラベル → ticket_types.name の対応（tanpuku は本アプリ独自で JRA テキストには現れない） */
-    private const TICKET_TYPE_MAP = [
-        '単勝' => TicketTypeName::Tansho->value,
-        '複勝' => TicketTypeName::Fukusho->value,
-        '枠連' => TicketTypeName::Wakuren->value,
-        'ワイド' => TicketTypeName::Wide->value,
-        '馬連' => TicketTypeName::Umaren->value,
-        '馬単' => TicketTypeName::Umatan->value,
-        '3連複' => TicketTypeName::Sanrenpuku->value,
-        '3連単' => TicketTypeName::Sanrentan->value,
-    ];
-
-    /**
-     * 必須券種（枠連は任意のため含めない）。
-     * 枠連は8頭以下で同一枠に2頭以上いない場合に非発売となるため、
-     * JRA券種のうち頭数起因で非発売となり得る唯一の券種である。
-     */
-    private const REQUIRED_TYPES = [
-        TicketTypeName::Tansho->value,
-        TicketTypeName::Fukusho->value,
-        TicketTypeName::Wide->value,
-        TicketTypeName::Umaren->value,
-        TicketTypeName::Umatan->value,
-        TicketTypeName::Sanrenpuku->value,
-        TicketTypeName::Sanrentan->value,
-    ];
-
     public function __construct(
         private readonly CalculatePayoutAmountAction $calculatePayoutAmountAction,
         private readonly RaceResultHorseParser $raceResultHorseParser,
+        private readonly RaceResultPayoutParser $raceResultPayoutParser,
     ) {}
 
     /**
@@ -76,13 +50,13 @@ class StoreAction
         }
 
         try {
-            $entries = $this->parse($data['text']);
-            $this->validateAllTypesPresent($entries);
+            $entries = $this->raceResultPayoutParser->parse($data['text']);
+            $this->raceResultPayoutParser->validateAllTypesPresent($entries);
         } catch (\InvalidArgumentException $e) {
             throw new ParseException($e->getMessage(), 'text');
         }
 
-        $ticketTypeIds = TicketType::whereIn('name', array_values(self::TICKET_TYPE_MAP))
+        $ticketTypeIds = TicketType::whereIn('name', array_values(RaceResultPayoutParser::TICKET_TYPE_MAP))
             ->pluck('id', 'name')
             ->all();
 
@@ -143,174 +117,6 @@ class StoreAction
                 $purchase->payout_amount = $payoutAmount;
                 $purchase->save();
             }
-        }
-    }
-
-    /**
-     * JRA払い戻しテキストをパースし、各行を独立したエントリとして返す。
-     * 複勝・ワイドなど複数行の券種は、各行がそれぞれ独立した払い戻し明細となる。
-     *
-     * @return array<int, array{ticket_type: string, horse_numbers: array<int, int>, amount: int, popularity: int}>
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function parse(string $text): array
-    {
-        $lines = preg_split('/\r?\n/', trim($text));
-        if ($lines === false || $lines === []) {
-            throw new \InvalidArgumentException('テキストが空です。');
-        }
-
-        /** @var array<int, array{ticket_type: string, horse_numbers: array<int, int>, amount: int, popularity: int}> $entries */
-        $entries = [];
-        $currentTicketType = null;
-
-        foreach ($lines as $lineNumber => $line) {
-            $line = rtrim($line);
-            if ($line === '') {
-                continue;
-            }
-
-            $columns = explode("\t", $line);
-            $ticketLabel = trim($columns[0]);
-
-            // JRAコピペフォーマット: 券種名のみの行（例: "単勝"）
-            if (count($columns) === 1) {
-                if (! isset(self::TICKET_TYPE_MAP[$ticketLabel])) {
-                    throw new \InvalidArgumentException(
-                        sprintf('%d行目: データの形式が認識できません。', $lineNumber + 1)
-                    );
-                }
-                $currentTicketType = self::TICKET_TYPE_MAP[$ticketLabel];
-
-                continue;
-            }
-
-            // JRAコピペフォーマット: データ行（例: "3\t610円\t2番人気"）
-            if (count($columns) === 3 && ! isset(self::TICKET_TYPE_MAP[$ticketLabel])) {
-                $horseCol = $columns[0];
-                $amountCol = $columns[1];
-                $popularityCol = $columns[2];
-            }
-            // インライン / 継続フォーマット（例: "単勝\t3\t610円\t2番人気" or "\t6\t110円\t1番人気"）
-            elseif (count($columns) >= 4) {
-                if ($ticketLabel !== '') {
-                    if (! isset(self::TICKET_TYPE_MAP[$ticketLabel])) {
-                        throw new \InvalidArgumentException(
-                            sprintf('%d行目: 不明な券種「%s」です。', $lineNumber + 1, $ticketLabel)
-                        );
-                    }
-                    $currentTicketType = self::TICKET_TYPE_MAP[$ticketLabel];
-                }
-                $horseCol = $columns[1] ?? '';
-                $amountCol = $columns[2] ?? '';
-                $popularityCol = $columns[3] ?? '';
-            } else {
-                throw new \InvalidArgumentException(
-                    sprintf('%d行目: データの形式が認識できません。', $lineNumber + 1)
-                );
-            }
-
-            if ($currentTicketType === null) {
-                throw new \InvalidArgumentException(
-                    sprintf('%d行目: 券種名が特定できません。', $lineNumber + 1)
-                );
-            }
-
-            $entries[] = [
-                'ticket_type' => $currentTicketType,
-                'horse_numbers' => $this->parseHorseNumbers($horseCol, $lineNumber + 1),
-                'amount' => $this->parseAmount($amountCol, $lineNumber + 1),
-                'popularity' => $this->parsePopularity($popularityCol, $lineNumber + 1),
-            ];
-        }
-
-        return $entries;
-    }
-
-    /**
-     * @return array<int, int>
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function parseHorseNumbers(string $col, int $lineNumber): array
-    {
-        $col = trim($col);
-        if ($col === '') {
-            throw new \InvalidArgumentException(
-                sprintf('%d行目: 馬番が空です。', $lineNumber)
-            );
-        }
-
-        $parts = explode('-', $col);
-        $numbers = [];
-        foreach ($parts as $part) {
-            $part = trim($part);
-            if (! ctype_digit($part) || $part === '') {
-                throw new \InvalidArgumentException(
-                    sprintf('%d行目: 馬番「%s」が不正です。', $lineNumber, $col)
-                );
-            }
-            $numbers[] = (int) $part;
-        }
-
-        return $numbers;
-    }
-
-    /**
-     * @throws \InvalidArgumentException
-     */
-    private function parseAmount(string $col, int $lineNumber): int
-    {
-        $col = trim($col);
-        $cleaned = str_replace([',', '円'], '', $col);
-        if (! ctype_digit($cleaned) || $cleaned === '') {
-            throw new \InvalidArgumentException(
-                sprintf('%d行目: 金額「%s」が不正です。', $lineNumber, $col)
-            );
-        }
-
-        return (int) $cleaned;
-    }
-
-    /**
-     * @throws \InvalidArgumentException
-     */
-    private function parsePopularity(string $col, int $lineNumber): int
-    {
-        $col = trim($col);
-        $cleaned = str_replace('番人気', '', $col);
-        if (! ctype_digit($cleaned) || $cleaned === '') {
-            throw new \InvalidArgumentException(
-                sprintf('%d行目: 人気「%s」が不正です。', $lineNumber, $col)
-            );
-        }
-
-        return (int) $cleaned;
-    }
-
-    /**
-     * パース結果に必須券種（枠連を除く7券種）が揃っていることを検証する。
-     *
-     * @param  array<int, array{ticket_type: string, horse_numbers: array<int, int>, amount: int, popularity: int}>  $entries
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function validateAllTypesPresent(array $entries): void
-    {
-        $foundTypes = array_unique(array_column($entries, 'ticket_type'));
-        $missing = array_diff(self::REQUIRED_TYPES, $foundTypes);
-
-        if ($missing !== []) {
-            $missingLabels = [];
-            $labelMap = array_flip(self::TICKET_TYPE_MAP);
-            foreach ($missing as $name) {
-                $missingLabels[] = $labelMap[$name] ?? $name;
-            }
-
-            throw new \InvalidArgumentException(
-                sprintf('以下の券種が不足しています: %s', implode('、', $missingLabels))
-            );
         }
     }
 }

--- a/source/tests/Unit/RaceResultPayoutParserTest.php
+++ b/source/tests/Unit/RaceResultPayoutParserTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\TicketTypeName;
 use App\Services\RaceResultPayoutParser;
+use InvalidArgumentException;
 
 /**
  * 7券種すべてを含む完全なJRAコピペ形式の払戻テキスト（枠連なし）
@@ -238,7 +239,7 @@ test('throws when text is empty', function () {
 
     // Act & Assert
     expect(fn () => $parser->parse(''))
-        ->toThrow(\InvalidArgumentException::class, 'テキストが空です。');
+        ->toThrow(InvalidArgumentException::class, 'テキストが空です。');
 });
 
 test('throws when ticket-type-only line is unknown', function () {
@@ -250,7 +251,7 @@ test('throws when ticket-type-only line is unknown', function () {
     ]);
 
     // Act & Assert
-    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+    expect(fn () => $parser->parse($text))->toThrow(InvalidArgumentException::class);
 });
 
 test('throws when inline format ticket type is unknown', function () {
@@ -259,7 +260,7 @@ test('throws when inline format ticket type is unknown', function () {
     $text = "謎券種\t3\t610円\t2番人気";
 
     // Act & Assert
-    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+    expect(fn () => $parser->parse($text))->toThrow(InvalidArgumentException::class);
 });
 
 test('throws when line has invalid column count', function () {
@@ -271,7 +272,7 @@ test('throws when line has invalid column count', function () {
     ]);
 
     // Act & Assert
-    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+    expect(fn () => $parser->parse($text))->toThrow(InvalidArgumentException::class);
 });
 
 test('throws when data line appears before any ticket type is established', function () {
@@ -280,7 +281,7 @@ test('throws when data line appears before any ticket type is established', func
     $text = "3\t610円\t2番人気";
 
     // Act & Assert
-    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+    expect(fn () => $parser->parse($text))->toThrow(InvalidArgumentException::class);
 });
 
 test('throws when data column is invalid', function (string $dataLine) {
@@ -289,7 +290,7 @@ test('throws when data column is invalid', function (string $dataLine) {
     $text = "単勝\n".$dataLine;
 
     // Act & Assert
-    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+    expect(fn () => $parser->parse($text))->toThrow(InvalidArgumentException::class);
 })->with([
     'empty horse number' => "\t610円\t2番人気",
     'non-numeric horse number' => "A-B\t610円\t2番人気",
@@ -322,7 +323,7 @@ test('throws when entries is empty', function () {
     $parser = new RaceResultPayoutParser;
 
     // Act & Assert
-    expect(fn () => $parser->validateAllTypesPresent([]))->toThrow(\InvalidArgumentException::class);
+    expect(fn () => $parser->validateAllTypesPresent([]))->toThrow(InvalidArgumentException::class);
 });
 
 test('throws when only wakuren is present and required types are missing', function () {
@@ -333,7 +334,7 @@ test('throws when only wakuren is present and required types are missing', funct
     ];
 
     // Act & Assert
-    expect(fn () => $parser->validateAllTypesPresent($entries))->toThrow(\InvalidArgumentException::class);
+    expect(fn () => $parser->validateAllTypesPresent($entries))->toThrow(InvalidArgumentException::class);
 });
 
 test('throws and includes missing ticket label in Japanese when one type is missing', function () {
@@ -350,7 +351,7 @@ test('throws and includes missing ticket label in Japanese when one type is miss
 
     // Act & Assert
     expect(fn () => $parser->validateAllTypesPresent($entries))
-        ->toThrow(\InvalidArgumentException::class, '単勝');
+        ->toThrow(InvalidArgumentException::class, '単勝');
 });
 
 test('throws when multiple required types are missing', function () {
@@ -365,5 +366,5 @@ test('throws when multiple required types are missing', function () {
     ];
 
     // Act & Assert
-    expect(fn () => $parser->validateAllTypesPresent($entries))->toThrow(\InvalidArgumentException::class);
+    expect(fn () => $parser->validateAllTypesPresent($entries))->toThrow(InvalidArgumentException::class);
 });

--- a/source/tests/Unit/RaceResultPayoutParserTest.php
+++ b/source/tests/Unit/RaceResultPayoutParserTest.php
@@ -237,7 +237,8 @@ test('throws when text is empty', function () {
     $parser = new RaceResultPayoutParser;
 
     // Act & Assert
-    expect(fn () => $parser->parse(''))->toThrow(\InvalidArgumentException::class);
+    expect(fn () => $parser->parse(''))
+        ->toThrow(\InvalidArgumentException::class, 'テキストが空です。');
 });
 
 test('throws when ticket-type-only line is unknown', function () {
@@ -282,53 +283,19 @@ test('throws when data line appears before any ticket type is established', func
     expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
 });
 
-test('throws when horse number is empty', function () {
+test('throws when data column is invalid', function (string $dataLine) {
     // Arrange
     $parser = new RaceResultPayoutParser;
-    $text = implode("\n", [
-        '単勝',
-        "\t610円\t2番人気",
-    ]);
+    $text = "単勝\n".$dataLine;
 
     // Act & Assert
     expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
-});
-
-test('throws when horse number is not numeric', function () {
-    // Arrange
-    $parser = new RaceResultPayoutParser;
-    $text = implode("\n", [
-        '単勝',
-        "A-B\t610円\t2番人気",
-    ]);
-
-    // Act & Assert
-    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
-});
-
-test('throws when amount is invalid', function () {
-    // Arrange
-    $parser = new RaceResultPayoutParser;
-    $text = implode("\n", [
-        '単勝',
-        "3\tabc円\t2番人気",
-    ]);
-
-    // Act & Assert
-    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
-});
-
-test('throws when popularity is invalid', function () {
-    // Arrange
-    $parser = new RaceResultPayoutParser;
-    $text = implode("\n", [
-        '単勝',
-        "3\t610円\tabc番人気",
-    ]);
-
-    // Act & Assert
-    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
-});
+})->with([
+    'empty horse number' => "\t610円\t2番人気",
+    'non-numeric horse number' => "A-B\t610円\t2番人気",
+    'invalid amount' => "3\tabc円\t2番人気",
+    'invalid popularity' => "3\t610円\tabc番人気",
+]);
 
 // ===== RaceResultPayoutParser::validateAllTypesPresent() =====
 
@@ -348,6 +315,14 @@ test('does not throw when all seven required ticket types are present', function
     // Act & Assert
     $parser->validateAllTypesPresent($entries);
     expect(true)->toBe(true);
+});
+
+test('throws when entries is empty', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+
+    // Act & Assert
+    expect(fn () => $parser->validateAllTypesPresent([]))->toThrow(\InvalidArgumentException::class);
 });
 
 test('throws when only wakuren is present and required types are missing', function () {

--- a/source/tests/Unit/RaceResultPayoutParserTest.php
+++ b/source/tests/Unit/RaceResultPayoutParserTest.php
@@ -1,0 +1,394 @@
+<?php
+
+use App\Enums\TicketTypeName;
+use App\Services\RaceResultPayoutParser;
+
+/**
+ * 7券種すべてを含む完全なJRAコピペ形式の払戻テキスト（枠連なし）
+ */
+$completePayoutTextWithoutWakuren = implode("\n", [
+    '単勝',
+    "3\t610円\t2番人気",
+    '複勝',
+    "3\t110円\t1番人気",
+    "6\t220円\t3番人気",
+    "9\t150円\t2番人気",
+    'ワイド',
+    "3-6\t450円\t2番人気",
+    "3-9\t380円\t1番人気",
+    "6-9\t520円\t3番人気",
+    '馬連',
+    "3-6\t1,200円\t4番人気",
+    '馬単',
+    "3-6\t2,400円\t7番人気",
+    '3連複',
+    "3-6-9\t1,800円\t5番人気",
+    '3連単',
+    "3-6-9\t8,500円\t12番人気",
+]);
+
+/**
+ * 8券種すべてを含む完全なJRAコピペ形式の払戻テキスト（枠連あり）
+ */
+$completePayoutTextWithWakuren = implode("\n", [
+    '単勝',
+    "3\t610円\t2番人気",
+    '複勝',
+    "3\t110円\t1番人気",
+    "6\t220円\t3番人気",
+    "9\t150円\t2番人気",
+    '枠連',
+    "2-4\t900円\t3番人気",
+    'ワイド',
+    "3-6\t450円\t2番人気",
+    "3-9\t380円\t1番人気",
+    "6-9\t520円\t3番人気",
+    '馬連',
+    "3-6\t1,200円\t4番人気",
+    '馬単',
+    "3-6\t2,400円\t7番人気",
+    '3連複',
+    "3-6-9\t1,800円\t5番人気",
+    '3連単',
+    "3-6-9\t8,500円\t12番人気",
+]);
+
+// ===== RaceResultPayoutParser::parse() 正常系 =====
+
+test('parses JRA copy-paste format with ticket-type-only line followed by data line', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '単勝',
+        "3\t610円\t2番人気",
+    ]);
+
+    // Act
+    $result = $parser->parse($text);
+
+    // Assert
+    expect(count($result))->toBe(1);
+    expect($result[0]['ticket_type'])->toBe(TicketTypeName::Tansho->value);
+    expect($result[0]['horse_numbers'])->toBe([3]);
+    expect($result[0]['amount'])->toBe(610);
+    expect($result[0]['popularity'])->toBe(2);
+});
+
+test('parses inline format with ticket type, horse number, amount, popularity in one line', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = "単勝\t3\t610円\t2番人気";
+
+    // Act
+    $result = $parser->parse($text);
+
+    // Assert
+    expect(count($result))->toBe(1);
+    expect($result[0]['ticket_type'])->toBe(TicketTypeName::Tansho->value);
+    expect($result[0]['horse_numbers'])->toBe([3]);
+    expect($result[0]['amount'])->toBe(610);
+    expect($result[0]['popularity'])->toBe(2);
+});
+
+test('parses continuation format where leading column is empty', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        "複勝\t3\t110円\t1番人気",
+        "\t6\t220円\t3番人気",
+    ]);
+
+    // Act
+    $result = $parser->parse($text);
+
+    // Assert
+    expect(count($result))->toBe(2);
+    expect($result[0]['ticket_type'])->toBe(TicketTypeName::Fukusho->value);
+    expect($result[1]['ticket_type'])->toBe(TicketTypeName::Fukusho->value);
+});
+
+test('multi-row ticket types (fukusho, wide) produce independent entries per line', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '複勝',
+        "3\t110円\t1番人気",
+        "6\t220円\t3番人気",
+        "9\t150円\t2番人気",
+    ]);
+
+    // Act
+    $result = $parser->parse($text);
+
+    // Assert
+    expect(count($result))->toBe(3);
+    expect($result[0]['ticket_type'])->toBe(TicketTypeName::Fukusho->value);
+    expect($result[1]['ticket_type'])->toBe(TicketTypeName::Fukusho->value);
+    expect($result[2]['ticket_type'])->toBe(TicketTypeName::Fukusho->value);
+});
+
+test('amount with comma is parsed correctly', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '3連単',
+        "1-2-3\t12,380円\t5番人気",
+    ]);
+
+    // Act
+    $result = $parser->parse($text);
+
+    // Assert
+    expect($result[0]['amount'])->toBe(12380);
+});
+
+test('multiple horse numbers separated by hyphen are parsed into array', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '馬連',
+        "3-6\t1,200円\t4番人気",
+    ]);
+
+    // Act
+    $result = $parser->parse($text);
+
+    // Assert
+    expect($result[0]['horse_numbers'])->toBe([3, 6]);
+});
+
+test('three-horse ticket parses three horse numbers', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '3連複',
+        "1-2-3\t820円\t1番人気",
+    ]);
+
+    // Act
+    $result = $parser->parse($text);
+
+    // Assert
+    expect($result[0]['horse_numbers'])->toBe([1, 2, 3]);
+});
+
+test('parses complete payout text with seven required ticket types (no wakuren)', function () use ($completePayoutTextWithoutWakuren) {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+
+    // Act
+    $result = $parser->parse($completePayoutTextWithoutWakuren);
+
+    // Assert
+    $ticketTypes = array_map(fn ($entry) => $entry['ticket_type'], $result);
+    expect($ticketTypes)->toContain(TicketTypeName::Tansho->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Fukusho->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Wide->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Umaren->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Umatan->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Sanrenpuku->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Sanrentan->value);
+});
+
+test('parses complete payout text with all eight ticket types (with wakuren)', function () use ($completePayoutTextWithWakuren) {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+
+    // Act
+    $result = $parser->parse($completePayoutTextWithWakuren);
+
+    // Assert
+    $ticketTypes = array_map(fn ($entry) => $entry['ticket_type'], $result);
+    expect($ticketTypes)->toContain(TicketTypeName::Tansho->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Fukusho->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Wakuren->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Wide->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Umaren->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Umatan->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Sanrenpuku->value);
+    expect($ticketTypes)->toContain(TicketTypeName::Sanrentan->value);
+});
+
+test('blank lines are ignored', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '単勝',
+        '',
+        "3\t610円\t2番人気",
+        '',
+        '複勝',
+        "3\t110円\t1番人気",
+    ]);
+
+    // Act
+    $result = $parser->parse($text);
+
+    // Assert
+    expect(count($result))->toBe(2);
+    expect($result[0]['ticket_type'])->toBe(TicketTypeName::Tansho->value);
+    expect($result[1]['ticket_type'])->toBe(TicketTypeName::Fukusho->value);
+});
+
+// ===== RaceResultPayoutParser::parse() 異常系 =====
+
+test('throws when text is empty', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+
+    // Act & Assert
+    expect(fn () => $parser->parse(''))->toThrow(\InvalidArgumentException::class);
+});
+
+test('throws when ticket-type-only line is unknown', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '謎券種',
+        "3\t610円\t2番人気",
+    ]);
+
+    // Act & Assert
+    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+});
+
+test('throws when inline format ticket type is unknown', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = "謎券種\t3\t610円\t2番人気";
+
+    // Act & Assert
+    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+});
+
+test('throws when line has invalid column count', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '単勝',
+        "3\t610円",
+    ]);
+
+    // Act & Assert
+    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+});
+
+test('throws when data line appears before any ticket type is established', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = "3\t610円\t2番人気";
+
+    // Act & Assert
+    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+});
+
+test('throws when horse number is empty', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '単勝',
+        "\t610円\t2番人気",
+    ]);
+
+    // Act & Assert
+    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+});
+
+test('throws when horse number is not numeric', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '単勝',
+        "A-B\t610円\t2番人気",
+    ]);
+
+    // Act & Assert
+    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+});
+
+test('throws when amount is invalid', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '単勝',
+        "3\tabc円\t2番人気",
+    ]);
+
+    // Act & Assert
+    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+});
+
+test('throws when popularity is invalid', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $text = implode("\n", [
+        '単勝',
+        "3\t610円\tabc番人気",
+    ]);
+
+    // Act & Assert
+    expect(fn () => $parser->parse($text))->toThrow(\InvalidArgumentException::class);
+});
+
+// ===== RaceResultPayoutParser::validateAllTypesPresent() =====
+
+test('does not throw when all seven required ticket types are present', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $entries = [
+        ['ticket_type' => TicketTypeName::Tansho->value, 'horse_numbers' => [3], 'amount' => 610, 'popularity' => 2],
+        ['ticket_type' => TicketTypeName::Fukusho->value, 'horse_numbers' => [3], 'amount' => 110, 'popularity' => 1],
+        ['ticket_type' => TicketTypeName::Wide->value, 'horse_numbers' => [3, 6], 'amount' => 450, 'popularity' => 2],
+        ['ticket_type' => TicketTypeName::Umaren->value, 'horse_numbers' => [3, 6], 'amount' => 1200, 'popularity' => 4],
+        ['ticket_type' => TicketTypeName::Umatan->value, 'horse_numbers' => [3, 6], 'amount' => 2400, 'popularity' => 7],
+        ['ticket_type' => TicketTypeName::Sanrenpuku->value, 'horse_numbers' => [3, 6, 9], 'amount' => 1800, 'popularity' => 5],
+        ['ticket_type' => TicketTypeName::Sanrentan->value, 'horse_numbers' => [3, 6, 9], 'amount' => 8500, 'popularity' => 12],
+    ];
+
+    // Act & Assert
+    $parser->validateAllTypesPresent($entries);
+    expect(true)->toBe(true);
+});
+
+test('throws when only wakuren is present and required types are missing', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $entries = [
+        ['ticket_type' => TicketTypeName::Wakuren->value, 'horse_numbers' => [2, 4], 'amount' => 900, 'popularity' => 3],
+    ];
+
+    // Act & Assert
+    expect(fn () => $parser->validateAllTypesPresent($entries))->toThrow(\InvalidArgumentException::class);
+});
+
+test('throws and includes missing ticket label in Japanese when one type is missing', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $entries = [
+        ['ticket_type' => TicketTypeName::Fukusho->value, 'horse_numbers' => [3], 'amount' => 110, 'popularity' => 1],
+        ['ticket_type' => TicketTypeName::Wide->value, 'horse_numbers' => [3, 6], 'amount' => 450, 'popularity' => 2],
+        ['ticket_type' => TicketTypeName::Umaren->value, 'horse_numbers' => [3, 6], 'amount' => 1200, 'popularity' => 4],
+        ['ticket_type' => TicketTypeName::Umatan->value, 'horse_numbers' => [3, 6], 'amount' => 2400, 'popularity' => 7],
+        ['ticket_type' => TicketTypeName::Sanrenpuku->value, 'horse_numbers' => [3, 6, 9], 'amount' => 1800, 'popularity' => 5],
+        ['ticket_type' => TicketTypeName::Sanrentan->value, 'horse_numbers' => [3, 6, 9], 'amount' => 8500, 'popularity' => 12],
+    ];
+
+    // Act & Assert
+    expect(fn () => $parser->validateAllTypesPresent($entries))
+        ->toThrow(\InvalidArgumentException::class, '単勝');
+});
+
+test('throws when multiple required types are missing', function () {
+    // Arrange
+    $parser = new RaceResultPayoutParser;
+    $entries = [
+        ['ticket_type' => TicketTypeName::Wide->value, 'horse_numbers' => [3, 6], 'amount' => 450, 'popularity' => 2],
+        ['ticket_type' => TicketTypeName::Umaren->value, 'horse_numbers' => [3, 6], 'amount' => 1200, 'popularity' => 4],
+        ['ticket_type' => TicketTypeName::Umatan->value, 'horse_numbers' => [3, 6], 'amount' => 2400, 'popularity' => 7],
+        ['ticket_type' => TicketTypeName::Sanrenpuku->value, 'horse_numbers' => [3, 6, 9], 'amount' => 1800, 'popularity' => 5],
+        ['ticket_type' => TicketTypeName::Sanrentan->value, 'horse_numbers' => [3, 6, 9], 'amount' => 8500, 'popularity' => 12],
+    ];
+
+    // Act & Assert
+    expect(fn () => $parser->validateAllTypesPresent($entries))->toThrow(\InvalidArgumentException::class);
+});


### PR DESCRIPTION
## やったこと

- `StoreAction` が内包していた払戻テキストのパース責務を専用サービスクラス `RaceResultPayoutParser` に切り出した
- 移管対象: `TICKET_TYPE_MAP` / `REQUIRED_TYPES` 定数、`parse()` / `validateAllTypesPresent()` (public)、`parseHorseNumbers()` / `parseAmount()` / `parsePopularity()` (private)
- `StoreAction` は `RaceResultPayoutParser` を DI で受け取り、パース処理を委譲する形に変更
- 合わせて `tests/Unit/RaceResultPayoutParserTest.php` を新規作成（23ケース）
- 外部インターフェース（入力テキスト形式・返却配列構造）は変更なし

## 結果

- `RaceResultPayoutParserTest`: 23/23 件パス
- `RaceResultTest` (Feature) の store 系テスト 33 件はリファクタ前後で変わらず通過
  - 失敗している 10 件（edit page の Inertia レスポンス系）はリファクタ前から存在する既存問題のため本 PR のスコープ外

## 動作確認済み

- [ ] 