### PR TITLE
[patch] レース結果入力画面の戻るボタンを履歴ベースの遷移に変更

### DIFF
--- a/source/resources/js/features/raceResult/containers/RaceResultFormContainer/index.tsx
+++ b/source/resources/js/features/raceResult/containers/RaceResultFormContainer/index.tsx
@@ -51,7 +51,6 @@ const RaceResultFormContainer = ({
 
 	return (
 		<RaceResultForm
-			raceUid={raceUid}
 			venueName={venueName}
 			raceDate={raceDate}
 			raceNumber={raceNumber}

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/RaceResultForm.unit.test.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/RaceResultForm.unit.test.tsx
@@ -3,18 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import RaceResultForm from "./index";
 
-vi.mock("@inertiajs/react", () => ({
-	Link: ({
-		href,
-		children,
-	}: {
-		href: string;
-		children: React.ReactNode;
-	}) => <a href={href}>{children}</a>,
-}));
-
 const baseProps = {
-	raceUid: "test-race-uid",
 	venueName: "東京",
 	raceDate: "2026-04-05",
 	raceNumber: 1,
@@ -215,26 +204,28 @@ describe("RaceResultForm", () => {
 	});
 
 	describe("戻るボタン", () => {
-		it("「レース結果へ戻る」テキストのリンクが表示される", () => {
+		it("「戻る」テキストのボタンが表示される", () => {
 			// Act
 			render(<RaceResultForm {...baseProps} />);
 
 			// Assert
 			expect(
-				screen.getByRole("link", { name: "レース結果へ戻る" }),
+				screen.getByRole("button", { name: "戻る" }),
 			).toBeInTheDocument();
 		});
 
-		it("「レース結果へ戻る」リンクの href が `/races/{raceUid}/result/edit` になっている", () => {
+		it("「戻る」ボタンをクリックすると window.history.back() が呼ばれる", async () => {
+			// Arrange
+			const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
+			const user = userEvent.setup();
+
 			// Act
 			render(<RaceResultForm {...baseProps} />);
+			await user.click(screen.getByRole("button", { name: "戻る" }));
 
 			// Assert
-			const link = screen.getByRole("link", { name: "レース結果へ戻る" });
-			expect(link).toHaveAttribute(
-				"href",
-				"/races/test-race-uid/result/edit",
-			);
+			expect(backSpy).toHaveBeenCalledTimes(1);
+			backSpy.mockRestore();
 		});
 	});
 });

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/index.stories.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/index.stories.tsx
@@ -12,7 +12,6 @@ type Story = StoryObj<typeof RaceResultForm>;
 
 const baseArgs: Pick<
 	RaceResultFormProps,
-	| "raceUid"
 	| "venueName"
 	| "raceDate"
 	| "raceNumber"
@@ -21,7 +20,6 @@ const baseArgs: Pick<
 	| "onSubmit"
 	| "isSubmitting"
 > = {
-	raceUid: "test-race-uid-123",
 	venueName: "東京",
 	raceDate: "2026-04-08",
 	raceNumber: 11,

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/index.tsx
@@ -1,12 +1,10 @@
 import AlertError from "@/components/presentational/AlertError";
 import BackButton from "@/components/presentational/BackButton";
 import { Button } from "@/components/shadcn/ui/button";
-import { edit as raceResultEdit } from "@/routes/races/result";
 import { formatDateDisplay } from "@/utils/date";
 import type { RaceResultFormProps } from "./types";
 
 const RaceResultForm = ({
-	raceUid,
 	venueName,
 	raceDate,
 	raceNumber,
@@ -23,10 +21,7 @@ const RaceResultForm = ({
 	return (
 		<div className="flex flex-col gap-6 p-4">
 			<div>
-				<BackButton
-					label="レース結果へ戻る"
-					href={raceResultEdit.url({ uid: raceUid })}
-				/>
+				<BackButton label="戻る" />
 			</div>
 			<div>
 				<h1 className="text-xl font-semibold">レース結果入力</h1>

--- a/source/resources/js/features/raceResult/presentational/RaceResultForm/types.ts
+++ b/source/resources/js/features/raceResult/presentational/RaceResultForm/types.ts
@@ -1,5 +1,4 @@
 export type RaceResultFormProps = {
-	raceUid: string;
 	venueName: string;
 	raceDate: string;
 	raceNumber: number;


### PR DESCRIPTION
## やったこと

- `RaceResultForm` の戻るボタンを固定 URL（`/races/{uid}/result/edit`）への遷移から `window.history.back()` による履歴ベース遷移に変更
- ボタンのラベルを「レース結果へ戻る」から汎用的な「戻る」に変更
- 不要になった `raceUid` prop を `RaceResultFormProps` から削除（`RaceResultFormContainer` は URL 組み立てに引き続き使用）
- 単体テストを新しい挙動（`window.history.back()` が呼ばれること）に合わせて更新

## 結果

<\!-- スクリーンショット・動画を添付する -->

## 動作確認済み

- [ ] レース詳細画面 → レース結果入力画面 と遷移し、戻るボタンでレース詳細画面に戻れること
- [ ] 別ルートからレース結果入力画面に来た場合も、戻るボタンでその遷移元に戻れること