### PR TITLE
[patch] 馬体重のカッコなし形式をパース可能にする

### DIFF
--- a/source/app/Services/RaceResultHorseParser.php
+++ b/source/app/Services/RaceResultHorseParser.php
@@ -24,8 +24,8 @@ namespace App\Services;
  */
 class RaceResultHorseParser
 {
-    /** 馬体重と増減（例: "500(+2)", "490(初出走)", "510(0)", "480(-4)") */
-    private const HORSE_WEIGHT_PATTERN = '/^(\d+)\(([^)]*)\)$/u';
+    /** 馬体重と増減（例: "500", "500(+2)", "490(初出走)", "510(0)", "480(-4)") */
+    private const HORSE_WEIGHT_PATTERN = '/^(\d+)(?:\(([^)]*)\))?$/u';
 
     /**
      * 着順テキストをパースし、各馬のデータを配列で返す。
@@ -367,7 +367,7 @@ class RaceResultHorseParser
     }
 
     /**
-     * 馬体重文字列（例: "500(+2)", "490(初出走)", "510(0)"）をパースする。
+     * 馬体重文字列（例: "500", "500(+2)", "490(初出走)", "510(0)"）をパースする。
      *
      * @return array{0: int|null, 1: int|null}
      *
@@ -386,6 +386,11 @@ class RaceResultHorseParser
         }
 
         $horseWeight = (int) $matches[1];
+
+        if (! isset($matches[2])) {
+            return [$horseWeight, null];
+        }
+
         $changeStr = $matches[2];
 
         if ($changeStr === '初出走') {

--- a/source/tests/Unit/RaceResultHorseParserTest.php
+++ b/source/tests/Unit/RaceResultHorseParserTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Services\RaceResultHorseParser;
+use InvalidArgumentException;
+
+/**
+ * 3行形式の着順テキストブロックを構築する。
+ * `{馬体重}` 部分のみテストごとに差し替えるためのヘルパー。
+ */
+$buildResultText = function (string $horseWeight): string {
+    return "1\t枠1白\t1\tテスト馬\t牡4\t57.0\tテスト騎手\t1:35.0\t\n"
+        ."1 1 1 1\n"
+        ."35.5\t{$horseWeight}\tテスト調教師\t1";
+};
+
+// ===== RaceResultHorseParser::parse() 馬体重パース 正常系 =====
+
+test('parses horse weight column into expected horse_weight and horse_weight_change', function (string $horseWeightInput, ?int $expectedWeight, ?int $expectedChange) use ($buildResultText) {
+    // Arrange
+    $parser = new RaceResultHorseParser;
+    $text = $buildResultText($horseWeightInput);
+
+    // Act
+    $result = $parser->parse($text);
+
+    // Assert
+    expect($result[0]['horse_weight'])->toBe($expectedWeight);
+    expect($result[0]['horse_weight_change'])->toBe($expectedChange);
+})->with([
+    'weight only without parentheses' => ['508', 508, null],
+    'weight with positive change' => ['508(+4)', 508, 4],
+    'weight with negative change' => ['508(-2)', 508, -2],
+    'weight with zero change' => ['508(0)', 508, 0],
+    'weight with first-run marker' => ['508(初出走)', 508, null],
+    'empty horse weight column' => ['', null, null],
+]);
+
+// ===== RaceResultHorseParser::parse() 馬体重パース 異常系 =====
+
+test('throws when horse weight column is malformed', function () use ($buildResultText) {
+    // Arrange
+    $parser = new RaceResultHorseParser;
+    $text = $buildResultText('abc');
+
+    // Act & Assert
+    expect(fn () => $parser->parse($text))->toThrow(InvalidArgumentException::class);
+});


### PR DESCRIPTION
## やったこと

- `RaceResultHorseParser` の馬体重パターン正規表現をカッコ部分オプションに変更し、カッコなし形式（例: `508`）を許容するようにした
- カッコなしの場合は `horse_weight_change` を `null` として返すよう実装を追加した
- 上記に対応するユニットテストを追加した

## 結果

なし（内部パース処理のみ・UIなし）

## 動作確認済み

- [ ] 追加したユニットテスト（正常系・異常系）がすべてパスすることを確認