### PR TITLE
[patch] RaceDetailContainer をカスタムフック 4 本に分割

### DIFF
--- a/source/resources/js/features/raceDetail/containers/RaceDetailContainer/index.tsx
+++ b/source/resources/js/features/raceDetail/containers/RaceDetailContainer/index.tsx
@@ -2,26 +2,18 @@ import { useState } from "react";
 import { toast } from "sonner";
 import HorseNoteModalContainer from "@/features/horseNote/containers/HorseNoteModalContainer";
 import type { HorseNote } from "@/features/horseNote/types/horseNote";
+import { useRaceDetailModals } from "@/features/raceDetail/hooks/useRaceDetailModals";
+import { useRaceMarkColumns } from "@/features/raceDetail/hooks/useRaceMarkColumns";
+import { useRaceMarkMemos } from "@/features/raceDetail/hooks/useRaceMarkMemos";
+import { useRaceMarks } from "@/features/raceDetail/hooks/useRaceMarks";
 import RaceDetail from "@/features/raceDetail/presentational/RaceDetail";
 import type {
-	MarkValue,
 	RaceDetailItem,
 	RaceEntry,
-	RaceMarkColumn,
-	RaceMarkMemo,
-	RaceMarkValue,
 } from "@/features/raceDetail/presentational/RaceDetail/types";
-import {
-	createOtherColumn,
-	deleteColumn,
-	updateColumnLabel,
-} from "@/features/raceDetail/requests/raceMarkColumns";
-import { upsertMark } from "@/features/raceDetail/requests/raceMarks";
+import { deleteColumn } from "@/features/raceDetail/requests/raceMarkColumns";
 import RaceMarkMemoModalContainer from "@/features/raceMarkMemo/containers/RaceMarkMemoModalContainer";
-import { useDebouncedCallbackByKey } from "@/hooks/useDebouncedCallback";
 import { formatDateDisplay } from "@/utils/date";
-
-const LABEL_DEBOUNCE_MS = 500;
 
 type Props = {
 	race: RaceDetailItem & {
@@ -35,146 +27,31 @@ const buildRaceLabel = (race: Props["race"]): string => {
 	return race.race_name != null ? `${base} ${race.race_name}` : base;
 };
 
-/**
- * レース詳細画面のコンテナ。
- * 印列・印データ・印メモのローカル state を保持し、ユーザー操作で楽観的に更新→API 呼び出し。
- * API 失敗時は state を元に戻して toast でエラーを通知する。
- * ラベル編集はキー入力中の連打を避けるため列ごとに 500ms デバウンスする。
- */
 const RaceDetailContainer = ({ race }: Props) => {
-	const [markColumns, setMarkColumns] = useState<RaceMarkColumn[]>(
-		race.mark_columns,
-	);
-	const [marks, setMarks] = useState<RaceMarkValue[]>(race.marks);
-	const [markMemos, setMarkMemos] = useState<RaceMarkMemo[]>(
-		race.mark_memos ?? [],
-	);
 	const [entries, setEntries] = useState<RaceEntry[]>(race.entries);
-	const [noteModal, setNoteModal] = useState<{
-		open: boolean;
-		horseId: number | null;
-		horseName: string;
-	}>({ open: false, horseId: null, horseName: "" });
-	const [memoModal, setMemoModal] = useState<{
-		open: boolean;
-		columnId: number | null;
-		raceEntryId: number | null;
-	}>({ open: false, columnId: null, raceEntryId: null });
-
-	const labelDebouncer = useDebouncedCallbackByKey(
-		async (raceUid: string, columnId: number, label: string) => {
-			try {
-				await updateColumnLabel(raceUid, columnId, label);
-			} catch (_e) {
-				toast.error("ラベルの更新に失敗しました");
-			}
-		},
-		LABEL_DEBOUNCE_MS,
-	);
-
-	const localRace: RaceDetailItem = {
-		...race,
+	const columnsHook = useRaceMarkColumns(race.uid, race.mark_columns);
+	const marksHook = useRaceMarks(race.uid, race.marks);
+	const memosHook = useRaceMarkMemos(race.mark_memos ?? []);
+	const modals = useRaceDetailModals({
 		entries,
-		mark_columns: markColumns,
-		marks,
-		mark_memos: markMemos,
-	};
-
-	const handleAddOtherColumn = async () => {
-		const tempId = -Date.now();
-		const maxOrder = markColumns.reduce(
-			(acc, c) => (c.display_order > acc ? c.display_order : acc),
-			0,
-		);
-		const optimistic: RaceMarkColumn = {
-			id: tempId,
-			type: "other",
-			label: "",
-			display_order: maxOrder + 1,
-		};
-		const previous = markColumns;
-		setMarkColumns([...previous, optimistic]);
-		try {
-			const created = await createOtherColumn(race.uid, "");
-			setMarkColumns((current) =>
-				current.map((c) => (c.id === tempId ? created : c)),
-			);
-		} catch (_e) {
-			setMarkColumns(previous);
-			toast.error("印列の追加に失敗しました");
-		}
-	};
+		markColumns: columnsHook.markColumns,
+		marks: marksHook.marks,
+		markMemos: memosHook.markMemos,
+	});
 
 	const handleRemoveOtherColumn = async (columnId: number) => {
-		labelDebouncer.cancel(columnId);
-		const previousColumns = markColumns;
-		const previousMarks = marks;
-		const previousMemos = markMemos;
-		setMarkColumns((current) => current.filter((c) => c.id !== columnId));
-		setMarks((current) => current.filter((m) => m.column_id !== columnId));
-		setMarkMemos((current) => current.filter((m) => m.column_id !== columnId));
+		columnsHook.cancelLabelDebounce(columnId);
+		const colSnap = columnsHook.removeColumnLocally(columnId);
+		const markSnap = marksHook.removeByColumnLocally(columnId);
+		const memoSnap = memosHook.removeByColumnLocally(columnId);
 		try {
 			await deleteColumn(race.uid, columnId);
 		} catch (_e) {
-			setMarkColumns(previousColumns);
-			setMarks(previousMarks);
-			setMarkMemos(previousMemos);
+			columnsHook.restoreColumns(colSnap);
+			marksHook.restoreSnapshot(markSnap);
+			memosHook.restoreSnapshot(memoSnap);
 			toast.error("印列の削除に失敗しました");
 		}
-	};
-
-	const handleChangeColumnLabel = (columnId: number, label: string) => {
-		setMarkColumns((current) =>
-			current.map((c) => (c.id === columnId ? { ...c, label } : c)),
-		);
-		labelDebouncer.call(columnId, race.uid, columnId, label);
-	};
-
-	const handleMarkChange = async (params: {
-		columnId: number;
-		raceEntryId: number;
-		markValue: MarkValue | null;
-	}) => {
-		const { columnId, raceEntryId, markValue } = params;
-		const previous = marks;
-		const filtered = marks.filter(
-			(m) =>
-				!(m.column_id === columnId && m.race_entry_id === raceEntryId),
-		);
-		const next: RaceMarkValue[] =
-			markValue === null
-				? filtered
-				: [
-						...filtered,
-						{
-							column_id: columnId,
-							race_entry_id: raceEntryId,
-							mark_value: markValue,
-						},
-					];
-		setMarks(next);
-		try {
-			await upsertMark(race.uid, columnId, raceEntryId, markValue);
-		} catch (_e) {
-			setMarks(previous);
-			toast.error("印の更新に失敗しました");
-		}
-	};
-
-	const handleNoteClick = (horseId: number) => {
-		const entry = entries.find((e) => e.horse_id === horseId);
-		if (entry == null) {
-			return;
-		}
-		setNoteModal({
-			open: true,
-			horseId: entry.horse_id,
-			horseName: entry.horse_name,
-		});
-	};
-
-	const handleNoteClose = () => {
-		setNoteModal((current) => ({ ...current, open: false }));
 	};
 
 	const handleNoteSuccess = (note: HorseNote) => {
@@ -195,137 +72,60 @@ const RaceDetailContainer = ({ race }: Props) => {
 		);
 	};
 
-	const handleMarkMemoClick = (params: {
-		columnId: number;
-		raceEntryId: number;
-	}) => {
-		setMemoModal({
-			open: true,
-			columnId: params.columnId,
-			raceEntryId: params.raceEntryId,
-		});
+	const localRace: RaceDetailItem = {
+		...race,
+		entries,
+		mark_columns: columnsHook.markColumns,
+		marks: marksHook.marks,
+		mark_memos: memosHook.markMemos,
 	};
-
-	const handleMemoClose = () => {
-		setMemoModal((current) => ({ ...current, open: false }));
-	};
-
-	const handleMemoSaved = (params: {
-		columnId: number;
-		raceEntryId: number;
-		content: string;
-	}) => {
-		setMarkMemos((current) => {
-			const filtered = current.filter(
-				(m) =>
-					!(
-						m.column_id === params.columnId &&
-						m.race_entry_id === params.raceEntryId
-					),
-			);
-			return [
-				...filtered,
-				{
-					column_id: params.columnId,
-					race_entry_id: params.raceEntryId,
-					content: params.content,
-				},
-			];
-		});
-	};
-
-	const handleMemoDeleted = (params: {
-		columnId: number;
-		raceEntryId: number;
-	}) => {
-		setMarkMemos((current) =>
-			current.filter(
-				(m) =>
-					!(
-						m.column_id === params.columnId &&
-						m.race_entry_id === params.raceEntryId
-					),
-			),
-		);
-	};
-
-	const selectedEntry =
-		noteModal.horseId != null
-			? entries.find((e) => e.horse_id === noteModal.horseId)
-			: undefined;
-	const selectedNote = selectedEntry?.note ?? null;
-
-	const memoTargetColumn =
-		memoModal.columnId != null
-			? markColumns.find((c) => c.id === memoModal.columnId)
-			: undefined;
-	const memoTargetEntry =
-		memoModal.raceEntryId != null
-			? entries.find((e) => e.id === memoModal.raceEntryId)
-			: undefined;
-	const memoTargetMemo =
-		memoModal.columnId != null && memoModal.raceEntryId != null
-			? markMemos.find(
-					(m) =>
-						m.column_id === memoModal.columnId &&
-						m.race_entry_id === memoModal.raceEntryId,
-				)
-			: undefined;
-	const memoTargetMark =
-		memoModal.columnId != null && memoModal.raceEntryId != null
-			? marks.find(
-					(m) =>
-						m.column_id === memoModal.columnId &&
-						m.race_entry_id === memoModal.raceEntryId,
-				)
-			: undefined;
 
 	return (
 		<>
 			<RaceDetail
 				race={localRace}
-				onMarkChange={handleMarkChange}
-				onAddOtherColumn={handleAddOtherColumn}
+				onMarkChange={marksHook.handleMarkChange}
+				onAddOtherColumn={columnsHook.handleAddOtherColumn}
 				onRemoveOtherColumn={handleRemoveOtherColumn}
-				onChangeColumnLabel={handleChangeColumnLabel}
-				onNoteClick={handleNoteClick}
-				onMarkMemoClick={handleMarkMemoClick}
+				onChangeColumnLabel={columnsHook.handleChangeColumnLabel}
+				onNoteClick={modals.handleNoteClick}
+				onMarkMemoClick={modals.handleMarkMemoClick}
 			/>
-			{noteModal.horseId != null && (
+			{modals.noteModal.horseId != null && (
 				<HorseNoteModalContainer
-					open={noteModal.open}
-					mode={selectedNote != null ? "edit" : "create"}
-					horseId={noteModal.horseId}
-					horseName={noteModal.horseName}
-					noteId={selectedNote?.id}
-					initialContent={selectedNote?.content ?? ""}
-					raceId={selectedNote != null ? null : (race.id ?? null)}
+					open={modals.noteModal.open}
+					mode={modals.selectedNote != null ? "edit" : "create"}
+					horseId={modals.noteModal.horseId}
+					horseName={modals.noteModal.horseName}
+					noteId={modals.selectedNote?.id}
+					initialContent={modals.selectedNote?.content ?? ""}
+					raceId={modals.selectedNote != null ? null : (race.id ?? null)}
 					raceContext={
-						selectedNote != null && selectedNote.source === "horse"
+						modals.selectedNote != null && modals.selectedNote.source === "horse"
 							? { type: "none" }
 							: { type: "fixed", label: buildRaceLabel(race) }
 					}
-					onClose={handleNoteClose}
+					onClose={modals.handleNoteClose}
 					onSuccess={handleNoteSuccess}
 				/>
 			)}
-			{memoModal.columnId != null &&
-				memoModal.raceEntryId != null &&
-				memoTargetColumn != null &&
-				memoTargetEntry != null && (
+			{modals.memoModal.columnId != null &&
+				modals.memoModal.raceEntryId != null &&
+				modals.memoTargetColumn != null &&
+				modals.memoTargetEntry != null && (
 					<RaceMarkMemoModalContainer
-						open={memoModal.open}
-						mode={memoTargetMemo != null ? "edit" : "create"}
+						open={modals.memoModal.open}
+						mode={modals.memoTargetMemo != null ? "edit" : "create"}
 						raceUid={race.uid}
-						columnId={memoModal.columnId}
-						raceEntryId={memoModal.raceEntryId}
-						horseName={memoTargetEntry.horse_name}
-						columnLabel={memoTargetColumn.label ?? ""}
-						markValue={memoTargetMark?.mark_value ?? null}
-						initialContent={memoTargetMemo?.content ?? ""}
-						onClose={handleMemoClose}
-						onSaved={handleMemoSaved}
-						onDeleted={handleMemoDeleted}
+						columnId={modals.memoModal.columnId}
+						raceEntryId={modals.memoModal.raceEntryId}
+						horseName={modals.memoTargetEntry.horse_name}
+						columnLabel={modals.memoTargetColumn.label ?? ""}
+						markValue={modals.memoTargetMark?.mark_value ?? null}
+						initialContent={modals.memoTargetMemo?.content ?? ""}
+						onClose={modals.handleMemoClose}
+						onSaved={memosHook.handleMemoSaved}
+						onDeleted={memosHook.handleMemoDeleted}
 					/>
 				)}
 		</>

--- a/source/resources/js/features/raceDetail/hooks/useRaceDetailModals.int.test.ts
+++ b/source/resources/js/features/raceDetail/hooks/useRaceDetailModals.int.test.ts
@@ -1,0 +1,45 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type {
+	RaceEntry,
+	RaceMarkColumn,
+	RaceMarkMemo,
+	RaceMarkValue,
+} from "@/features/raceDetail/presentational/RaceDetail/types";
+import { useRaceDetailModals } from "./useRaceDetailModals";
+
+const entry: RaceEntry = {
+	id: 1,
+	frame_number: 2,
+	horse_number: 3,
+	horse_id: 42,
+	horse_name: "テストホース",
+	jockey_name: "テスト騎手",
+	weight: 480,
+};
+
+describe("useRaceDetailModals", () => {
+	it("ハッピーパス: handleNoteClick を呼ぶと noteModal が open になり、selectedEntry が該当 entry を返すこと", () => {
+		// Arrange
+		const entries: RaceEntry[] = [entry];
+		const markColumns: RaceMarkColumn[] = [];
+		const marks: RaceMarkValue[] = [];
+		const markMemos: RaceMarkMemo[] = [];
+		const { result } = renderHook(() =>
+			useRaceDetailModals({ entries, markColumns, marks, markMemos }),
+		);
+
+		// Act
+		act(() => {
+			result.current.handleNoteClick(42);
+		});
+
+		// Assert
+		expect(result.current.noteModal).toEqual({
+			open: true,
+			horseId: 42,
+			horseName: "テストホース",
+		});
+		expect(result.current.selectedEntry).toBe(entry);
+	});
+});

--- a/source/resources/js/features/raceDetail/hooks/useRaceDetailModals.ts
+++ b/source/resources/js/features/raceDetail/hooks/useRaceDetailModals.ts
@@ -1,0 +1,159 @@
+import { useMemo, useState } from "react";
+import type {
+	RaceEntry,
+	RaceEntryNote,
+	RaceMarkColumn,
+	RaceMarkMemo,
+	RaceMarkValue,
+} from "@/features/raceDetail/presentational/RaceDetail/types";
+
+type NoteModalState = {
+	open: boolean;
+	horseId: number | null;
+	horseName: string;
+};
+
+type MemoModalState = {
+	open: boolean;
+	columnId: number | null;
+	raceEntryId: number | null;
+};
+
+type UseRaceDetailModalsParams = {
+	entries: ReadonlyArray<RaceEntry>;
+	markColumns: ReadonlyArray<RaceMarkColumn>;
+	marks: ReadonlyArray<RaceMarkValue>;
+	markMemos: ReadonlyArray<RaceMarkMemo>;
+};
+
+type UseRaceDetailModalsReturn = {
+	noteModal: NoteModalState;
+	selectedEntry: RaceEntry | undefined;
+	selectedNote: RaceEntryNote | null;
+	handleNoteClick: (horseId: number) => void;
+	handleNoteClose: () => void;
+
+	memoModal: MemoModalState;
+	memoTargetColumn: RaceMarkColumn | undefined;
+	memoTargetEntry: RaceEntry | undefined;
+	memoTargetMemo: RaceMarkMemo | undefined;
+	memoTargetMark: RaceMarkValue | undefined;
+	handleMarkMemoClick: (params: {
+		columnId: number;
+		raceEntryId: number;
+	}) => void;
+	handleMemoClose: () => void;
+};
+
+/**
+ * レース詳細画面の馬メモ・印メモモーダル開閉 state と、モーダル props 計算用の派生 state を管理する。
+ * 派生 state は entries / markColumns / marks / markMemos から useMemo で導出するため、関係ない再レンダーで再計算されない。
+ */
+export const useRaceDetailModals = (
+	params: UseRaceDetailModalsParams,
+): UseRaceDetailModalsReturn => {
+	const { entries, markColumns, marks, markMemos } = params;
+
+	const [noteModal, setNoteModal] = useState<NoteModalState>({
+		open: false,
+		horseId: null,
+		horseName: "",
+	});
+	const [memoModal, setMemoModal] = useState<MemoModalState>({
+		open: false,
+		columnId: null,
+		raceEntryId: null,
+	});
+
+	const handleNoteClick = (horseId: number) => {
+		const entry = entries.find((e) => e.horse_id === horseId);
+		if (entry == null) {
+			return;
+		}
+		setNoteModal({
+			open: true,
+			horseId: entry.horse_id,
+			horseName: entry.horse_name,
+		});
+	};
+
+	const handleNoteClose = () => {
+		setNoteModal((current) => ({ ...current, open: false }));
+	};
+
+	const handleMarkMemoClick = (params: {
+		columnId: number;
+		raceEntryId: number;
+	}) => {
+		setMemoModal({
+			open: true,
+			columnId: params.columnId,
+			raceEntryId: params.raceEntryId,
+		});
+	};
+
+	const handleMemoClose = () => {
+		setMemoModal((current) => ({ ...current, open: false }));
+	};
+
+	const selectedEntry = useMemo(
+		() =>
+			noteModal.horseId != null
+				? entries.find((e) => e.horse_id === noteModal.horseId)
+				: undefined,
+		[entries, noteModal.horseId],
+	);
+	const selectedNote: RaceEntryNote | null = selectedEntry?.note ?? null;
+
+	const memoTargetColumn = useMemo(
+		() =>
+			memoModal.columnId != null
+				? markColumns.find((c) => c.id === memoModal.columnId)
+				: undefined,
+		[markColumns, memoModal.columnId],
+	);
+	const memoTargetEntry = useMemo(
+		() =>
+			memoModal.raceEntryId != null
+				? entries.find((e) => e.id === memoModal.raceEntryId)
+				: undefined,
+		[entries, memoModal.raceEntryId],
+	);
+	const memoTargetMemo = useMemo(
+		() =>
+			memoModal.columnId != null && memoModal.raceEntryId != null
+				? markMemos.find(
+						(m) =>
+							m.column_id === memoModal.columnId &&
+							m.race_entry_id === memoModal.raceEntryId,
+					)
+				: undefined,
+		[markMemos, memoModal.columnId, memoModal.raceEntryId],
+	);
+	const memoTargetMark = useMemo(
+		() =>
+			memoModal.columnId != null && memoModal.raceEntryId != null
+				? marks.find(
+						(m) =>
+							m.column_id === memoModal.columnId &&
+							m.race_entry_id === memoModal.raceEntryId,
+					)
+				: undefined,
+		[marks, memoModal.columnId, memoModal.raceEntryId],
+	);
+
+	return {
+		noteModal,
+		selectedEntry,
+		selectedNote,
+		handleNoteClick,
+		handleNoteClose,
+		memoModal,
+		memoTargetColumn,
+		memoTargetEntry,
+		memoTargetMemo,
+		memoTargetMark,
+		handleMarkMemoClick,
+		handleMemoClose,
+	};
+};

--- a/source/resources/js/features/raceDetail/hooks/useRaceMarkColumns.int.test.ts
+++ b/source/resources/js/features/raceDetail/hooks/useRaceMarkColumns.int.test.ts
@@ -1,0 +1,46 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/features/raceDetail/requests/raceMarkColumns", () => ({
+	createOtherColumn: vi.fn(),
+	updateColumnLabel: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+	toast: { error: vi.fn() },
+}));
+
+import { createOtherColumn } from "@/features/raceDetail/requests/raceMarkColumns";
+import type { RaceMarkColumn } from "@/features/raceDetail/presentational/RaceDetail/types";
+import { useRaceMarkColumns } from "./useRaceMarkColumns";
+
+describe("useRaceMarkColumns", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("ハッピーパス: handleAddOtherColumn を呼ぶと createOtherColumn API が叩かれ、楽観的に追加された一時行がレスポンスで置き換わること", async () => {
+		// Arrange
+		const initial: RaceMarkColumn[] = [
+			{ id: 1, type: "own", label: null, display_order: 0 },
+		];
+		const created: RaceMarkColumn = {
+			id: 99,
+			type: "other",
+			label: "",
+			display_order: 1,
+		};
+		vi.mocked(createOtherColumn).mockResolvedValue(created);
+		const { result } = renderHook(() =>
+			useRaceMarkColumns("race-uid", initial),
+		);
+
+		// Act
+		await act(async () => {
+			await result.current.handleAddOtherColumn();
+		});
+
+		// Assert
+		expect(createOtherColumn).toHaveBeenCalledWith("race-uid", "");
+		expect(result.current.markColumns).toEqual([initial[0], created]);
+	});
+});

--- a/source/resources/js/features/raceDetail/hooks/useRaceMarkColumns.ts
+++ b/source/resources/js/features/raceDetail/hooks/useRaceMarkColumns.ts
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import type { RaceMarkColumn } from "@/features/raceDetail/presentational/RaceDetail/types";
+import {
+	createOtherColumn,
+	updateColumnLabel,
+} from "@/features/raceDetail/requests/raceMarkColumns";
+import { useDebouncedCallbackByKey } from "@/hooks/useDebouncedCallback";
+
+const LABEL_DEBOUNCE_MS = 500;
+
+type UseRaceMarkColumnsReturn = {
+	markColumns: RaceMarkColumn[];
+	handleAddOtherColumn: () => Promise<void>;
+	handleChangeColumnLabel: (columnId: number, label: string) => void;
+	removeColumnLocally: (columnId: number) => RaceMarkColumn[];
+	restoreColumns: (snapshot: RaceMarkColumn[]) => void;
+	cancelLabelDebounce: (columnId: number) => void;
+};
+
+/**
+ * 印列のローカル state と楽観的更新を管理する。
+ * 列追加（API 失敗時はロールバック）、ラベル編集（500ms デバウンス API）、ラベルデバウンスのキャンセルを提供する。
+ * 列削除そのものは marks/markMemos との横断ロールバックが必要なので、本フックは removeColumnLocally / restoreColumns を提供しコンテナでオーケストレーションする。
+ */
+export const useRaceMarkColumns = (
+	raceUid: string,
+	initial: RaceMarkColumn[],
+): UseRaceMarkColumnsReturn => {
+	const [markColumns, setMarkColumns] = useState<RaceMarkColumn[]>(initial);
+
+	const labelDebouncer = useDebouncedCallbackByKey(
+		async (uid: string, columnId: number, label: string) => {
+			try {
+				await updateColumnLabel(uid, columnId, label);
+			} catch (_e) {
+				toast.error("ラベルの更新に失敗しました");
+			}
+		},
+		LABEL_DEBOUNCE_MS,
+	);
+
+	const handleAddOtherColumn = async () => {
+		const tempId = -Date.now();
+		const maxOrder = markColumns.reduce(
+			(acc, c) => (c.display_order > acc ? c.display_order : acc),
+			0,
+		);
+		const optimistic: RaceMarkColumn = {
+			id: tempId,
+			type: "other",
+			label: "",
+			display_order: maxOrder + 1,
+		};
+		const previous = markColumns;
+		setMarkColumns([...previous, optimistic]);
+		try {
+			const created = await createOtherColumn(raceUid, "");
+			setMarkColumns((current) =>
+				current.map((c) => (c.id === tempId ? created : c)),
+			);
+		} catch (_e) {
+			setMarkColumns(previous);
+			toast.error("印列の追加に失敗しました");
+		}
+	};
+
+	const handleChangeColumnLabel = (columnId: number, label: string) => {
+		setMarkColumns((current) =>
+			current.map((c) => (c.id === columnId ? { ...c, label } : c)),
+		);
+		labelDebouncer.call(columnId, raceUid, columnId, label);
+	};
+
+	const removeColumnLocally = (columnId: number): RaceMarkColumn[] => {
+		const snapshot = markColumns;
+		setMarkColumns((current) => current.filter((c) => c.id !== columnId));
+		return snapshot;
+	};
+
+	const restoreColumns = (snapshot: RaceMarkColumn[]) => {
+		setMarkColumns(snapshot);
+	};
+
+	const cancelLabelDebounce = (columnId: number) => {
+		labelDebouncer.cancel(columnId);
+	};
+
+	return {
+		markColumns,
+		handleAddOtherColumn,
+		handleChangeColumnLabel,
+		removeColumnLocally,
+		restoreColumns,
+		cancelLabelDebounce,
+	};
+};

--- a/source/resources/js/features/raceDetail/hooks/useRaceMarkMemos.int.test.ts
+++ b/source/resources/js/features/raceDetail/hooks/useRaceMarkMemos.int.test.ts
@@ -1,0 +1,24 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useRaceMarkMemos } from "./useRaceMarkMemos";
+
+describe("useRaceMarkMemos", () => {
+	it("ハッピーパス: handleMemoSaved を呼ぶと該当 (columnId, raceEntryId) のメモが markMemos に upsert されること", () => {
+		// Arrange
+		const { result } = renderHook(() => useRaceMarkMemos([]));
+
+		// Act
+		act(() => {
+			result.current.handleMemoSaved({
+				columnId: 10,
+				raceEntryId: 20,
+				content: "メモ本文",
+			});
+		});
+
+		// Assert
+		expect(result.current.markMemos).toEqual([
+			{ column_id: 10, race_entry_id: 20, content: "メモ本文" },
+		]);
+	});
+});

--- a/source/resources/js/features/raceDetail/hooks/useRaceMarkMemos.ts
+++ b/source/resources/js/features/raceDetail/hooks/useRaceMarkMemos.ts
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import type { RaceMarkMemo } from "@/features/raceDetail/presentational/RaceDetail/types";
+
+type UseRaceMarkMemosReturn = {
+	markMemos: RaceMarkMemo[];
+	handleMemoSaved: (params: {
+		columnId: number;
+		raceEntryId: number;
+		content: string;
+	}) => void;
+	handleMemoDeleted: (params: {
+		columnId: number;
+		raceEntryId: number;
+	}) => void;
+	removeByColumnLocally: (columnId: number) => RaceMarkMemo[];
+	restoreSnapshot: (snapshot: RaceMarkMemo[]) => void;
+};
+
+/**
+ * 印メモのローカル state を管理する。
+ * API 呼び出しは RaceMarkMemoModalContainer 側が担うため、本フックは保存/削除完了の通知を受けて state を同期するだけ。
+ * removeByColumnLocally / restoreSnapshot は印列削除のオーケストレーション用。
+ */
+export const useRaceMarkMemos = (
+	initial: RaceMarkMemo[],
+): UseRaceMarkMemosReturn => {
+	const [markMemos, setMarkMemos] = useState<RaceMarkMemo[]>(initial);
+
+	const handleMemoSaved = (params: {
+		columnId: number;
+		raceEntryId: number;
+		content: string;
+	}) => {
+		setMarkMemos((current) => {
+			const filtered = current.filter(
+				(m) =>
+					!(
+						m.column_id === params.columnId &&
+						m.race_entry_id === params.raceEntryId
+					),
+			);
+			return [
+				...filtered,
+				{
+					column_id: params.columnId,
+					race_entry_id: params.raceEntryId,
+					content: params.content,
+				},
+			];
+		});
+	};
+
+	const handleMemoDeleted = (params: {
+		columnId: number;
+		raceEntryId: number;
+	}) => {
+		setMarkMemos((current) =>
+			current.filter(
+				(m) =>
+					!(
+						m.column_id === params.columnId &&
+						m.race_entry_id === params.raceEntryId
+					),
+			),
+		);
+	};
+
+	const removeByColumnLocally = (columnId: number): RaceMarkMemo[] => {
+		const snapshot = markMemos;
+		setMarkMemos((current) => current.filter((m) => m.column_id !== columnId));
+		return snapshot;
+	};
+
+	const restoreSnapshot = (snapshot: RaceMarkMemo[]) => {
+		setMarkMemos(snapshot);
+	};
+
+	return {
+		markMemos,
+		handleMemoSaved,
+		handleMemoDeleted,
+		removeByColumnLocally,
+		restoreSnapshot,
+	};
+};

--- a/source/resources/js/features/raceDetail/hooks/useRaceMarks.int.test.ts
+++ b/source/resources/js/features/raceDetail/hooks/useRaceMarks.int.test.ts
@@ -1,0 +1,39 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/features/raceDetail/requests/raceMarks", () => ({
+	upsertMark: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+	toast: { error: vi.fn() },
+}));
+
+import { upsertMark } from "@/features/raceDetail/requests/raceMarks";
+import { useRaceMarks } from "./useRaceMarks";
+
+describe("useRaceMarks", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("ハッピーパス: handleMarkChange を呼ぶと upsertMark が正しい引数で呼ばれ、marks に新しい印が追加されること", async () => {
+		// Arrange
+		vi.mocked(upsertMark).mockResolvedValue(null);
+		const { result } = renderHook(() => useRaceMarks("race-uid", []));
+
+		// Act
+		await act(async () => {
+			await result.current.handleMarkChange({
+				columnId: 10,
+				raceEntryId: 20,
+				markValue: "◎",
+			});
+		});
+
+		// Assert
+		expect(upsertMark).toHaveBeenCalledWith("race-uid", 10, 20, "◎");
+		expect(result.current.marks).toEqual([
+			{ column_id: 10, race_entry_id: 20, mark_value: "◎" },
+		]);
+	});
+});

--- a/source/resources/js/features/raceDetail/hooks/useRaceMarks.ts
+++ b/source/resources/js/features/raceDetail/hooks/useRaceMarks.ts
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import type {
+	MarkValue,
+	RaceMarkValue,
+} from "@/features/raceDetail/presentational/RaceDetail/types";
+import { upsertMark } from "@/features/raceDetail/requests/raceMarks";
+
+type UseRaceMarksReturn = {
+	marks: RaceMarkValue[];
+	handleMarkChange: (params: {
+		columnId: number;
+		raceEntryId: number;
+		markValue: MarkValue | null;
+	}) => Promise<void>;
+	removeByColumnLocally: (columnId: number) => RaceMarkValue[];
+	restoreSnapshot: (snapshot: RaceMarkValue[]) => void;
+};
+
+/**
+ * 印データのローカル state と楽観的 upsert を管理する。
+ * markValue が null のときは該当行を削除する。API 失敗時は state を戻して toast 通知する。
+ * removeByColumnLocally / restoreSnapshot は印列削除のオーケストレーション用。
+ */
+export const useRaceMarks = (
+	raceUid: string,
+	initial: RaceMarkValue[],
+): UseRaceMarksReturn => {
+	const [marks, setMarks] = useState<RaceMarkValue[]>(initial);
+
+	const handleMarkChange = async (params: {
+		columnId: number;
+		raceEntryId: number;
+		markValue: MarkValue | null;
+	}) => {
+		const { columnId, raceEntryId, markValue } = params;
+		const previous = marks;
+		const filtered = marks.filter(
+			(m) => !(m.column_id === columnId && m.race_entry_id === raceEntryId),
+		);
+		const next: RaceMarkValue[] =
+			markValue === null
+				? filtered
+				: [
+						...filtered,
+						{
+							column_id: columnId,
+							race_entry_id: raceEntryId,
+							mark_value: markValue,
+						},
+					];
+		setMarks(next);
+		try {
+			await upsertMark(raceUid, columnId, raceEntryId, markValue);
+		} catch (_e) {
+			setMarks(previous);
+			toast.error("印の更新に失敗しました");
+		}
+	};
+
+	const removeByColumnLocally = (columnId: number): RaceMarkValue[] => {
+		const snapshot = marks;
+		setMarks((current) => current.filter((m) => m.column_id !== columnId));
+		return snapshot;
+	};
+
+	const restoreSnapshot = (snapshot: RaceMarkValue[]) => {
+		setMarks(snapshot);
+	};
+
+	return {
+		marks,
+		handleMarkChange,
+		removeByColumnLocally,
+		restoreSnapshot,
+	};
+};


### PR DESCRIPTION
## やったこと

- `features/raceDetail/hooks/` を新設し、335 行あった `RaceDetailContainer` を 4 つのカスタムフックに分割
  - `useRaceMarks` — 印データの state・楽観的 upsert・API 失敗時ロールバック
  - `useRaceMarkMemos` — 印メモ state・保存/削除コールバック
  - `useRaceMarkColumns` — 印列 state・追加/ラベル変更(500ms デバウンス)
  - `useRaceDetailModals` — 馬メモ・印メモのモーダル state と派生 state (`useMemo` で最適化)
- コンテナ本体は約 130 行に縮小。残るロジックは 3 state 横断ロールバックが必要な印列削除のオーケストレーションのみ
- pure refactor — ユーザー向けの動作・見た目は変更なし

## 結果

スクリーンショット・動画なし（UI 変更なし）

## 動作確認済み

- [ ] 印クリックで反映 → API 呼び出し
- [ ] 印列ラベル連続入力 → 500ms 後に API が 1 回
- [ ] 印列追加・削除（削除時に印・印メモも同時に消える）
- [ ] 馬メモ・印メモモーダルの開閉・保存・削除