### PR TITLE
[patch] ensureOwnColumnExists() の重複を EnsureOwnColumnExistsAction に集約

### DIFF
--- a/source/app/UseCases/Race/ShowAction.php
+++ b/source/app/UseCases/Race/ShowAction.php
@@ -7,8 +7,8 @@ use App\Models\RaceMarkColumn;
 use App\Models\RaceMarkMemo;
 use App\Models\User;
 use App\UseCases\HorseNote\LoadNotesByHorseId;
+use App\UseCases\RaceMarkColumn\EnsureOwnColumnExistsAction;
 use Carbon\CarbonInterface;
-use Illuminate\Database\UniqueConstraintViolationException;
 
 /**
  * レースと出馬表（馬・騎手含む）に加え、認証ユーザーの印列・印データ・競走馬メモを取得し、
@@ -16,7 +16,10 @@ use Illuminate\Database\UniqueConstraintViolationException;
  */
 class ShowAction
 {
-    public function __construct(private LoadNotesByHorseId $loadNotesByHorseId) {}
+    public function __construct(
+        private LoadNotesByHorseId $loadNotesByHorseId,
+        private EnsureOwnColumnExistsAction $ensureOwnColumnExistsAction,
+    ) {}
 
     /**
      * @return array{
@@ -51,7 +54,7 @@ class ShowAction
             'raceEntries.jockey',
         ]);
 
-        $this->ensureOwnColumnExists($race, $user);
+        $this->ensureOwnColumnExistsAction->execute($race, $user);
 
         $columns = RaceMarkColumn::query()
             ->where('race_id', $race->id)
@@ -119,24 +122,5 @@ class ShowAction
             'mark_memos' => $markMemos,
             'has_result' => $race->raceResultHorses()->exists() || $race->racePayouts()->exists(),
         ];
-    }
-
-    private function ensureOwnColumnExists(Race $race, User $user): void
-    {
-        try {
-            RaceMarkColumn::firstOrCreate(
-                [
-                    'race_id' => $race->id,
-                    'user_id' => $user->id,
-                    'column_type' => 'own',
-                ],
-                [
-                    'label' => null,
-                    'display_order' => 0,
-                ],
-            );
-        } catch (UniqueConstraintViolationException) {
-            // 別リクエストが先に作成済み。次のクエリで読めるので無視。
-        }
     }
 }

--- a/source/app/UseCases/RaceMarkColumn/EnsureOwnColumnExistsAction.php
+++ b/source/app/UseCases/RaceMarkColumn/EnsureOwnColumnExistsAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\UseCases\RaceMarkColumn;
+
+use App\Models\Race;
+use App\Models\RaceMarkColumn;
+use App\Models\User;
+use Illuminate\Database\UniqueConstraintViolationException;
+
+/**
+ * 指定レース・ユーザーに対する RaceMarkColumn の "own" 列が存在しない場合に自動生成する。
+ */
+class EnsureOwnColumnExistsAction
+{
+    public function execute(Race $race, User $user): void
+    {
+        try {
+            RaceMarkColumn::firstOrCreate(
+                [
+                    'race_id' => $race->id,
+                    'user_id' => $user->id,
+                    'column_type' => 'own',
+                ],
+                [
+                    'label' => null,
+                    'display_order' => 0,
+                ],
+            );
+        } catch (UniqueConstraintViolationException) {
+            // 別リクエストが先に作成済み。次のクエリで読めるので無視。
+        }
+    }
+}

--- a/source/app/UseCases/RaceMarkColumn/EnsureOwnColumnExistsAction.php
+++ b/source/app/UseCases/RaceMarkColumn/EnsureOwnColumnExistsAction.php
@@ -12,6 +12,11 @@ use Illuminate\Database\UniqueConstraintViolationException;
  */
 class EnsureOwnColumnExistsAction
 {
+    /**
+     * 指定レース・ユーザーの "own" 列を冪等に生成する。
+     * 並行リクエストでの競合作成時に発生する UniqueConstraintViolationException は握り潰す
+     * （後続のクエリで作成済みレコードを読めるため）。
+     */
     public function execute(Race $race, User $user): void
     {
         try {

--- a/source/app/UseCases/RaceMarkColumn/IndexAction.php
+++ b/source/app/UseCases/RaceMarkColumn/IndexAction.php
@@ -5,7 +5,6 @@ namespace App\UseCases\RaceMarkColumn;
 use App\Models\Race;
 use App\Models\RaceMarkColumn;
 use App\Models\User;
-use Illuminate\Database\UniqueConstraintViolationException;
 
 /**
  * 認証ユーザー所有の印列を display_order 昇順で返す。
@@ -13,12 +12,14 @@ use Illuminate\Database\UniqueConstraintViolationException;
  */
 class IndexAction
 {
+    public function __construct(private EnsureOwnColumnExistsAction $ensureOwnColumnExistsAction) {}
+
     /**
      * @return array<int, array{id: int, type: string, label: string|null, display_order: int}>
      */
     public function execute(Race $race, User $user): array
     {
-        $this->ensureOwnColumnExists($race, $user);
+        $this->ensureOwnColumnExistsAction->execute($race, $user);
 
         return RaceMarkColumn::query()
             ->where('race_id', $race->id)
@@ -32,24 +33,5 @@ class IndexAction
                 'display_order' => (int) $column->display_order,
             ])
             ->all();
-    }
-
-    private function ensureOwnColumnExists(Race $race, User $user): void
-    {
-        try {
-            RaceMarkColumn::firstOrCreate(
-                [
-                    'race_id' => $race->id,
-                    'user_id' => $user->id,
-                    'column_type' => 'own',
-                ],
-                [
-                    'label' => null,
-                    'display_order' => 0,
-                ],
-            );
-        } catch (UniqueConstraintViolationException) {
-            // 別リクエストが先に作成済み。次のクエリで読めるので無視。
-        }
     }
 }


### PR DESCRIPTION
## やったこと

- `Race/ShowAction` と `RaceMarkColumn/IndexAction` の両クラスに完全一致で存在していた `ensureOwnColumnExists()` プライベートメソッドを廃止
- 共通ロジックを `app/UseCases/RaceMarkColumn/EnsureOwnColumnExistsAction` として切り出し
- 両 Action のコンストラクタへ DI で注入し、`$this->ensureOwnColumnExistsAction->execute($race, $user)` で呼び出すよう統一
- 既存の挙動（`firstOrCreate` の条件・デフォルト値・`UniqueConstraintViolationException` の握り潰し）は変えない

## 結果

バックエンドのリファクタリングのみのため、UI・APIレスポンスに変化なし。

## 動作確認済み

- [ ] 既存の Feature テスト（`RaceMarkColumnIndexTest`・`RaceShowTest`）が対象の挙動をカバー済み