### PR TITLE
[patch] レース・出馬バリデーションのマジックナンバーを定数化

### DIFF
--- a/source/app/Concerns/RaceEntryValidationRules.php
+++ b/source/app/Concerns/RaceEntryValidationRules.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Concerns;
+
+use App\Constants\Race as RaceConstants;
+use App\Models\Race;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Validation\Rule;
+
+trait RaceEntryValidationRules
+{
+    /**
+     * 出馬登録（追加・更新）で共通するバリデーションルールを返す。
+     *
+     * @param  Race  $race  対象レース（horse_number の一意性スコープに使用）
+     * @param  int|null  $ignoreEntryId  更新時に除外する race_entries.id
+     * @return array<string, array<int, ValidationRule|array<mixed>|string>>
+     */
+    protected function raceEntryRules(Race $race, ?int $ignoreEntryId = null): array
+    {
+        $uniqueRule = Rule::unique('race_entries', 'horse_number')
+            ->where(fn ($query) => $query->where('race_id', $race->id));
+
+        if ($ignoreEntryId !== null) {
+            $uniqueRule = $uniqueRule->ignore($ignoreEntryId);
+        }
+
+        return [
+            'horse_name' => ['required', 'string'],
+            'jockey_name' => ['required', 'string'],
+            'frame_number' => ['required', 'integer', 'between:1,'.RaceConstants::MAX_FRAME_NUMBER],
+            'horse_number' => [
+                'required',
+                'integer',
+                'between:1,'.RaceConstants::MAX_HORSE_NUMBER,
+                $uniqueRule,
+            ],
+            'weight' => ['required', 'numeric'],
+            'horse_weight' => ['nullable', 'integer'],
+        ];
+    }
+}

--- a/source/app/Constants/Race.php
+++ b/source/app/Constants/Race.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Constants;
+
+final class Race
+{
+    /**
+     * 枠番の最大値（枠番は 1〜8）。
+     */
+    public const MAX_FRAME_NUMBER = 8;
+
+    /**
+     * 馬番の最大値（馬番は 1〜18）。
+     */
+    public const MAX_HORSE_NUMBER = 18;
+
+    /**
+     * 1開催日の最大レース番号（1〜12）。
+     */
+    public const MAX_RACE_NUMBER = 12;
+
+    private function __construct() {}
+}

--- a/source/app/Http/Requests/Race/StoreRaceRequest.php
+++ b/source/app/Http/Requests/Race/StoreRaceRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Race;
 
+use App\Constants\Race;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -20,7 +21,7 @@ class StoreRaceRequest extends FormRequest
         return [
             'venue_id' => ['required', 'integer', 'exists:venues,id'],
             'race_date' => ['required', 'date'],
-            'race_number' => ['required', 'integer', 'between:1,12'],
+            'race_number' => ['required', 'integer', 'between:1,'.Race::MAX_RACE_NUMBER],
             'race_name' => ['nullable', 'string'],
             'paste_text' => ['required', 'string'],
         ];

--- a/source/app/Http/Requests/RaceEntry/AddSingleRaceEntryRequest.php
+++ b/source/app/Http/Requests/RaceEntry/AddSingleRaceEntryRequest.php
@@ -2,13 +2,15 @@
 
 namespace App\Http\Requests\RaceEntry;
 
+use App\Concerns\RaceEntryValidationRules;
 use App\Models\Race;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class AddSingleRaceEntryRequest extends FormRequest
 {
+    use RaceEntryValidationRules;
+
     public function authorize(): bool
     {
         return $this->user() !== null;
@@ -22,20 +24,7 @@ class AddSingleRaceEntryRequest extends FormRequest
         /** @var Race $race */
         $race = $this->route('race');
 
-        return [
-            'horse_name' => ['required', 'string'],
-            'jockey_name' => ['required', 'string'],
-            'frame_number' => ['required', 'integer', 'between:1,8'],
-            'horse_number' => [
-                'required',
-                'integer',
-                'between:1,18',
-                Rule::unique('race_entries', 'horse_number')
-                    ->where(fn ($query) => $query->where('race_id', $race->id)),
-            ],
-            'weight' => ['required', 'numeric'],
-            'horse_weight' => ['nullable', 'integer'],
-        ];
+        return $this->raceEntryRules($race);
     }
 
     /**

--- a/source/app/Http/Requests/RaceEntry/UpdateRaceEntryRequest.php
+++ b/source/app/Http/Requests/RaceEntry/UpdateRaceEntryRequest.php
@@ -2,14 +2,16 @@
 
 namespace App\Http\Requests\RaceEntry;
 
+use App\Concerns\RaceEntryValidationRules;
 use App\Models\Race;
 use App\Models\RaceEntry;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class UpdateRaceEntryRequest extends FormRequest
 {
+    use RaceEntryValidationRules;
+
     public function authorize(): bool
     {
         return $this->user() !== null;
@@ -25,21 +27,7 @@ class UpdateRaceEntryRequest extends FormRequest
         /** @var RaceEntry $entry */
         $entry = $this->route('entry');
 
-        return [
-            'horse_name' => ['required', 'string'],
-            'jockey_name' => ['required', 'string'],
-            'frame_number' => ['required', 'integer', 'between:1,8'],
-            'horse_number' => [
-                'required',
-                'integer',
-                'between:1,18',
-                Rule::unique('race_entries', 'horse_number')
-                    ->where(fn ($query) => $query->where('race_id', $race->id))
-                    ->ignore($entry->id),
-            ],
-            'weight' => ['required', 'numeric'],
-            'horse_weight' => ['nullable', 'integer'],
-        ];
+        return $this->raceEntryRules($race, $entry->id);
     }
 
     /**

--- a/source/app/Http/Requests/TicketPurchase/StoreTicketPurchaseRequest.php
+++ b/source/app/Http/Requests/TicketPurchase/StoreTicketPurchaseRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\TicketPurchase;
 
 use App\Constants\Money;
+use App\Constants\Race;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -26,7 +27,7 @@ class StoreTicketPurchaseRequest extends FormRequest
         return [
             'venue' => ['required', 'string', 'exists:venues,name'],
             'race_date' => ['nullable', 'date'],
-            'race_number' => ['nullable', 'integer', 'min:1', 'max:12'],
+            'race_number' => ['nullable', 'integer', 'min:1', 'max:'.Race::MAX_RACE_NUMBER],
             'ticket_type' => ['required', 'string', 'exists:ticket_types,name'],
             'buy_type' => ['required', 'string', 'exists:buy_types,name'],
             'selections' => ['required', 'array'],


### PR DESCRIPTION
## やったこと

- `app/Constants/Race.php` を新設し、`MAX_FRAME_NUMBER = 8`・`MAX_HORSE_NUMBER = 18`・`MAX_RACE_NUMBER = 12` を定義
- `app/Concerns/RaceEntryValidationRules.php` trait を新設し、`AddSingleRaceEntryRequest` / `UpdateRaceEntryRequest` の重複バリデーションルール（6フィールド）を一元化
- `StoreRaceRequest` / `StoreTicketPurchaseRequest` の race_number 上限値も定数参照に置換

## 結果

リファクタリングのみのため、UI への変化なし。

## 動作確認済み

- [ ] 既存テスト（RaceStore / RaceEntryUpdate / RaceEntryAddStore 系）がパスすることを確認