### PR TITLE
[minor] 収支ダッシュボードの日次収支に無限スクロール機能を追加

### DIFF
--- a/source/app/Http/Controllers/DashboardController.php
+++ b/source/app/Http/Controllers/DashboardController.php
@@ -14,13 +14,17 @@ class DashboardController extends Controller
         $year = $request->query('year');
         $year = $year !== null ? (int) $year : null;
 
-        $data = $action->execute($request->user()->id, $year);
+        $cursor = $request->query('cursor');
+        $cursor = $cursor !== null ? (string) $cursor : null;
+
+        $data = $action->execute($request->user()->id, $year, $cursor);
 
         return Inertia::render('dashboard', [
             'selected_year' => $data['selected_year'],
             'available_years' => $data['available_years'],
             'summary' => $data['summary'],
-            'daily_balances' => $data['daily_balances'],
+            'daily_balances' => Inertia::merge(fn () => $data['daily_balances']),
+            'next_cursor' => $data['next_cursor'],
         ]);
     }
 }

--- a/source/app/UseCases/Balance/ShowDashboardAction.php
+++ b/source/app/UseCases/Balance/ShowDashboardAction.php
@@ -14,7 +14,8 @@ use Illuminate\Support\Facades\DB;
  * ExpandSelectionsAction で展開した結果の件数。
  *
  * summary は年間全体で集計し、daily_balances のみカーソルページネーション
- * （30件/ページ、日付降順）を適用する。
+ * （30件/ページ、日付降順）を適用する。ページネーションはメモリ上で
+ * スライスするだけで、DB クエリ自体は year 内全件を取得する。
  */
 class ShowDashboardAction
 {
@@ -137,7 +138,15 @@ class ShowDashboardAction
             ];
         }
 
-        $cursorObj = $cursor !== null ? Cursor::fromEncoded($cursor) : null;
+        $cursorObj = null;
+        if ($cursor !== null) {
+            try {
+                // 不正なカーソルは先頭ページにフォールバック（古い URL の共有等で 500 を返さない）
+                $cursorObj = Cursor::fromEncoded($cursor);
+            } catch (\Throwable) {
+                $cursorObj = null;
+            }
+        }
 
         $itemsAfterCursor = $dailyBalances;
         if ($cursorObj !== null) {

--- a/source/app/UseCases/Balance/ShowDashboardAction.php
+++ b/source/app/UseCases/Balance/ShowDashboardAction.php
@@ -3,6 +3,8 @@
 namespace App\UseCases\Balance;
 
 use App\UseCases\TicketPurchase\ExpandSelectionsAction;
+use Illuminate\Pagination\Cursor;
+use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -10,9 +12,17 @@ use Illuminate\Support\Facades\DB;
  *
  * 購入金額は「単価 × 有効点数」で算出する。有効点数は selections を
  * ExpandSelectionsAction で展開した結果の件数。
+ *
+ * summary は年間全体で集計し、daily_balances のみカーソルページネーション
+ * （30件/ページ、日付降順）を適用する。
  */
 class ShowDashboardAction
 {
+    /**
+     * 1ページあたりの日次収支件数。
+     */
+    private const DAILY_BALANCES_PER_PAGE = 30;
+
     public function __construct(
         private ExpandSelectionsAction $expandSelections,
     ) {}
@@ -35,9 +45,10 @@ class ShowDashboardAction
      *     net_amount: int,
      *     return_rate: float,
      *   }>,
+     *   next_cursor: string|null,
      * }
      */
-    public function execute(int $userId, ?int $year = null): array
+    public function execute(int $userId, ?int $year = null, ?string $cursor = null): array
     {
         $selectedYear = $year ?? now()->year;
 
@@ -126,11 +137,32 @@ class ShowDashboardAction
             ];
         }
 
+        $cursorObj = $cursor !== null ? Cursor::fromEncoded($cursor) : null;
+
+        $itemsAfterCursor = $dailyBalances;
+        if ($cursorObj !== null) {
+            $cursorDate = $cursorObj->parameter('date');
+            $itemsAfterCursor = array_values(array_filter(
+                $dailyBalances,
+                fn (array $item): bool => $item['date'] < $cursorDate,
+            ));
+        }
+
+        $pageItems = array_slice($itemsAfterCursor, 0, self::DAILY_BALANCES_PER_PAGE + 1);
+
+        $paginator = new CursorPaginator(
+            $pageItems,
+            self::DAILY_BALANCES_PER_PAGE,
+            $cursorObj,
+            ['parameters' => ['date']],
+        );
+
         return [
             'selected_year' => $selectedYear,
             'available_years' => $availableYears,
             'summary' => $summary,
-            'daily_balances' => $dailyBalances,
+            'daily_balances' => array_values($paginator->items()),
+            'next_cursor' => $paginator->nextCursor()?->encode(),
         ];
     }
 }

--- a/source/resources/js/features/dashboard/presentational/BalanceDashboard/BalanceDashboard.unit.test.tsx
+++ b/source/resources/js/features/dashboard/presentational/BalanceDashboard/BalanceDashboard.unit.test.tsx
@@ -44,6 +44,9 @@ const baseProps: BalanceDashboardProps = {
 	summary: null,
 	dailyBalances: [],
 	onYearChange: vi.fn(),
+	hasMore: false,
+	isLoadingMore: false,
+	onLoadMore: vi.fn(),
 };
 
 const dummySummary: YearlySummary = {
@@ -229,6 +232,118 @@ describe("BalanceDashboard", () => {
 			// Assert
 			expect(onYearChange).toHaveBeenCalledWith(2025);
 			expect(typeof onYearChange.mock.calls[0][0]).toBe("number");
+		});
+	});
+
+	describe("もっと読み込む", () => {
+		it("hasMore=true のとき「もっと読み込む」ボタンが表示される", () => {
+			// Arrange
+			const props: BalanceDashboardProps = {
+				...baseProps,
+				dailyBalances: dummyDailyBalances,
+				hasMore: true,
+			};
+
+			// Act
+			render(<BalanceDashboard {...props} />);
+
+			// Assert
+			expect(
+				screen.getByRole("button", { name: "もっと読み込む" }),
+			).toBeInTheDocument();
+		});
+
+		it("hasMore=false のとき「もっと読み込む」ボタンが表示されない", () => {
+			// Arrange
+			const props: BalanceDashboardProps = {
+				...baseProps,
+				dailyBalances: dummyDailyBalances,
+				hasMore: false,
+			};
+
+			// Act
+			render(<BalanceDashboard {...props} />);
+
+			// Assert
+			expect(
+				screen.queryByRole("button", { name: "もっと読み込む" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("hasMore が未指定（デフォルト）のとき「もっと読み込む」ボタンが表示されない", () => {
+			// Arrange
+			const props: BalanceDashboardProps = {
+				selectedYear: 2026,
+				availableYears: [2025, 2026],
+				summary: null,
+				dailyBalances: dummyDailyBalances,
+				onYearChange: vi.fn(),
+			};
+
+			// Act
+			render(<BalanceDashboard {...props} />);
+
+			// Assert
+			expect(
+				screen.queryByRole("button", { name: "もっと読み込む" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("isLoadingMore=true のとき Spinner が表示される", () => {
+			// Arrange
+			const props: BalanceDashboardProps = {
+				...baseProps,
+				dailyBalances: dummyDailyBalances,
+				hasMore: true,
+				isLoadingMore: true,
+			};
+
+			// Act
+			render(<BalanceDashboard {...props} />);
+
+			// Assert
+			expect(screen.getByRole("status")).toBeInTheDocument();
+		});
+
+		it("isLoadingMore=true のとき「もっと読み込む」ボタンが表示されない", () => {
+			// Arrange
+			const props: BalanceDashboardProps = {
+				...baseProps,
+				dailyBalances: dummyDailyBalances,
+				hasMore: true,
+				isLoadingMore: true,
+			};
+
+			// Act
+			render(<BalanceDashboard {...props} />);
+
+			// Assert
+			expect(
+				screen.queryByRole("button", { name: "もっと読み込む" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("「もっと読み込む」ボタンをクリックすると onLoadMore が呼ばれる", async () => {
+			// Arrange
+			const onLoadMore = vi.fn();
+			const { default: userEvent } = await import(
+				"@testing-library/user-event"
+			);
+			const user = userEvent.setup();
+			const props: BalanceDashboardProps = {
+				...baseProps,
+				dailyBalances: dummyDailyBalances,
+				hasMore: true,
+				isLoadingMore: false,
+				onLoadMore,
+			};
+
+			// Act
+			render(<BalanceDashboard {...props} />);
+			await user.click(screen.getByRole("button", { name: "もっと読み込む" }));
+
+			// Assert
+			expect(onLoadMore).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.stories.tsx
+++ b/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.stories.tsx
@@ -12,11 +12,14 @@ type Story = StoryObj<typeof BalanceDashboard>;
 
 const baseArgs: Pick<
 	BalanceDashboardProps,
-	"selectedYear" | "availableYears" | "onYearChange"
+	"selectedYear" | "availableYears" | "onYearChange" | "hasMore" | "isLoadingMore" | "onLoadMore"
 > = {
 	selectedYear: 2026,
 	availableYears: [2024, 2025, 2026],
 	onYearChange: () => {},
+	hasMore: false,
+	isLoadingMore: false,
+	onLoadMore: () => {},
 };
 
 const sampleDailyBalances: BalanceDashboardProps["dailyBalances"] = [
@@ -48,6 +51,39 @@ const sampleDailyBalances: BalanceDashboardProps["dailyBalances"] = [
 		net_amount: 2800,
 		return_rate: 240.0,
 	},
+];
+
+const manyDailyBalances: BalanceDashboardProps["dailyBalances"] = [
+	{ date: "2026-01-04", purchase_amount: 3000, payout_amount: 4500, net_amount: 1500, return_rate: 150.0 },
+	{ date: "2026-01-11", purchase_amount: 5000, payout_amount: 3000, net_amount: -2000, return_rate: 60.0 },
+	{ date: "2026-01-18", purchase_amount: 8000, payout_amount: 9600, net_amount: 1600, return_rate: 120.0 },
+	{ date: "2026-01-25", purchase_amount: 4000, payout_amount: 3200, net_amount: -800, return_rate: 80.0 },
+	{ date: "2026-02-01", purchase_amount: 6000, payout_amount: 7800, net_amount: 1800, return_rate: 130.0 },
+	{ date: "2026-02-08", purchase_amount: 2000, payout_amount: 1400, net_amount: -600, return_rate: 70.0 },
+	{ date: "2026-02-15", purchase_amount: 10000, payout_amount: 12000, net_amount: 2000, return_rate: 120.0 },
+	{ date: "2026-02-22", purchase_amount: 5000, payout_amount: 4000, net_amount: -1000, return_rate: 80.0 },
+	{ date: "2026-03-01", purchase_amount: 3000, payout_amount: 5100, net_amount: 2100, return_rate: 170.0 },
+	{ date: "2026-03-08", purchase_amount: 7000, payout_amount: 5600, net_amount: -1400, return_rate: 80.0 },
+	{ date: "2026-03-15", purchase_amount: 4000, payout_amount: 4800, net_amount: 800, return_rate: 120.0 },
+	{ date: "2026-03-22", purchase_amount: 6000, payout_amount: 4200, net_amount: -1800, return_rate: 70.0 },
+	{ date: "2026-03-29", purchase_amount: 2000, payout_amount: 3000, net_amount: 1000, return_rate: 150.0 },
+	{ date: "2026-04-05", purchase_amount: 3000, payout_amount: 5000, net_amount: 2000, return_rate: 166.7 },
+	{ date: "2026-04-06", purchase_amount: 5000, payout_amount: 2000, net_amount: -3000, return_rate: 40.0 },
+	{ date: "2026-04-12", purchase_amount: 10000, payout_amount: 9500, net_amount: -500, return_rate: 95.0 },
+	{ date: "2026-04-13", purchase_amount: 2000, payout_amount: 4800, net_amount: 2800, return_rate: 240.0 },
+	{ date: "2026-04-19", purchase_amount: 8000, payout_amount: 6400, net_amount: -1600, return_rate: 80.0 },
+	{ date: "2026-04-20", purchase_amount: 4000, payout_amount: 5600, net_amount: 1600, return_rate: 140.0 },
+	{ date: "2026-04-26", purchase_amount: 6000, payout_amount: 4800, net_amount: -1200, return_rate: 80.0 },
+	{ date: "2026-04-27", purchase_amount: 3000, payout_amount: 4500, net_amount: 1500, return_rate: 150.0 },
+	{ date: "2026-05-03", purchase_amount: 5000, payout_amount: 3500, net_amount: -1500, return_rate: 70.0 },
+	{ date: "2026-05-04", purchase_amount: 7000, payout_amount: 9100, net_amount: 2100, return_rate: 130.0 },
+	{ date: "2026-05-05", purchase_amount: 10000, payout_amount: 8000, net_amount: -2000, return_rate: 80.0 },
+	{ date: "2026-05-10", purchase_amount: 2000, payout_amount: 3400, net_amount: 1400, return_rate: 170.0 },
+	{ date: "2026-05-11", purchase_amount: 4000, payout_amount: 2800, net_amount: -1200, return_rate: 70.0 },
+	{ date: "2026-05-17", purchase_amount: 6000, payout_amount: 7800, net_amount: 1800, return_rate: 130.0 },
+	{ date: "2026-05-18", purchase_amount: 3000, payout_amount: 2100, net_amount: -900, return_rate: 70.0 },
+	{ date: "2026-05-24", purchase_amount: 5000, payout_amount: 6500, net_amount: 1500, return_rate: 130.0 },
+	{ date: "2026-05-25", purchase_amount: 8000, payout_amount: 6400, net_amount: -1600, return_rate: 80.0 },
 ];
 
 export const Empty: Story = {
@@ -104,5 +140,56 @@ export const MobileWithData: Story = {
 			total_return_rate: 106.5,
 		},
 		dailyBalances: sampleDailyBalances,
+	},
+};
+
+export const Default: Story = {
+	name: "全件表示済み（もっと読み込むなし）",
+	args: {
+		...baseArgs,
+		hasMore: false,
+		isLoadingMore: false,
+		summary: {
+			year: 2026,
+			total_purchase_amount: 161000,
+			total_payout_amount: 156700,
+			total_net_amount: -4300,
+			total_return_rate: 97.3,
+		},
+		dailyBalances: manyDailyBalances,
+	},
+};
+
+export const HasMore: Story = {
+	name: "もっと読み込むボタン表示",
+	args: {
+		...baseArgs,
+		hasMore: true,
+		isLoadingMore: false,
+		summary: {
+			year: 2026,
+			total_purchase_amount: 161000,
+			total_payout_amount: 156700,
+			total_net_amount: -4300,
+			total_return_rate: 97.3,
+		},
+		dailyBalances: manyDailyBalances,
+	},
+};
+
+export const LoadingMore: Story = {
+	name: "追加読み込み中（Spinner表示）",
+	args: {
+		...baseArgs,
+		hasMore: true,
+		isLoadingMore: true,
+		summary: {
+			year: 2026,
+			total_purchase_amount: 161000,
+			total_payout_amount: 156700,
+			total_net_amount: -4300,
+			total_return_rate: 97.3,
+		},
+		dailyBalances: manyDailyBalances,
 	},
 };

--- a/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.tsx
+++ b/source/resources/js/features/dashboard/presentational/BalanceDashboard/index.tsx
@@ -11,6 +11,8 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/shadcn/ui/select";
+import { Button } from "@/components/shadcn/ui/button";
+import { Spinner } from "@/components/shadcn/ui/spinner";
 import ScrollableTable from "@/components/presentational/ScrollableTable";
 import { formatDateDisplay } from "@/utils/date";
 import type { BalanceDashboardProps } from "./types";
@@ -21,6 +23,9 @@ const BalanceDashboard = ({
 	summary,
 	dailyBalances,
 	onYearChange,
+	hasMore,
+	isLoadingMore,
+	onLoadMore,
 }: BalanceDashboardProps) => {
 	return (
 		<div className="flex flex-col gap-6 p-4">
@@ -138,60 +143,81 @@ const BalanceDashboard = ({
 						<p>記録がありません</p>
 					</div>
 				) : (
-					<ScrollableTable>
-						<thead>
-							<tr className="border-b bg-muted/50">
-								<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-									日付
-								</th>
-								<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-									購入金額
-								</th>
-								<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-									払い戻し金額
-								</th>
-								<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-									プラスマイナス
-								</th>
-								<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-									回収率
-								</th>
-							</tr>
-						</thead>
-						<tbody>
-							{dailyBalances.map((row) => (
-								<tr
-									key={row.date}
-									className="border-b last:border-0 hover:bg-muted/30"
-								>
-									<td className="px-4 py-3">{formatDateDisplay(row.date)}</td>
-									<td className="px-4 py-3 text-right">
-										¥{row.purchase_amount.toLocaleString()}
-									</td>
-									<td className="px-4 py-3 text-right">
-										¥{row.payout_amount.toLocaleString()}
-									</td>
-									<td
-										className={`px-4 py-3 text-right font-medium ${
-											row.net_amount >= 0 ? "text-green-600" : "text-red-600"
-										}`}
-									>
-										{row.net_amount >= 0 ? "+" : ""}¥
-										{row.net_amount.toLocaleString()}
-									</td>
-									<td
-										className={`px-4 py-3 text-right ${
-											row.return_rate >= 100
-												? "text-green-600"
-												: "text-red-600"
-										}`}
-									>
-										{row.return_rate.toFixed(1)}%
-									</td>
+					<>
+						<ScrollableTable>
+							<thead>
+								<tr className="border-b bg-muted/50">
+									<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+										日付
+									</th>
+									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+										購入金額
+									</th>
+									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+										払い戻し金額
+									</th>
+									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+										プラスマイナス
+									</th>
+									<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+										回収率
+									</th>
 								</tr>
-							))}
-						</tbody>
-					</ScrollableTable>
+							</thead>
+							<tbody>
+								{dailyBalances.map((row) => (
+									<tr
+										key={row.date}
+										className="border-b last:border-0 hover:bg-muted/30"
+									>
+										<td className="px-4 py-3">{formatDateDisplay(row.date)}</td>
+										<td className="px-4 py-3 text-right">
+											¥{row.purchase_amount.toLocaleString()}
+										</td>
+										<td className="px-4 py-3 text-right">
+											¥{row.payout_amount.toLocaleString()}
+										</td>
+										<td
+											className={`px-4 py-3 text-right font-medium ${
+												row.net_amount >= 0 ? "text-green-600" : "text-red-600"
+											}`}
+										>
+											{row.net_amount >= 0 ? "+" : ""}¥
+											{row.net_amount.toLocaleString()}
+										</td>
+										<td
+											className={`px-4 py-3 text-right ${
+												row.return_rate >= 100
+													? "text-green-600"
+													: "text-red-600"
+											}`}
+										>
+											{row.return_rate.toFixed(1)}%
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</ScrollableTable>
+
+						{hasMore && (
+							<div className="flex justify-center">
+								<Button
+									variant="outline"
+									onClick={onLoadMore}
+									disabled={isLoadingMore}
+								>
+									{isLoadingMore ? (
+										<>
+											<Spinner className="mr-2" />
+											読み込み中...
+										</>
+									) : (
+										"もっと読み込む"
+									)}
+								</Button>
+							</div>
+						)}
+					</>
 				)}
 			</div>
 		</div>

--- a/source/resources/js/features/dashboard/presentational/BalanceDashboard/types.ts
+++ b/source/resources/js/features/dashboard/presentational/BalanceDashboard/types.ts
@@ -20,4 +20,7 @@ export type BalanceDashboardProps = {
 	summary: YearlySummary | null;
 	dailyBalances: DailyBalance[];
 	onYearChange: (year: number) => void;
+	hasMore: boolean;
+	isLoadingMore: boolean;
+	onLoadMore: () => void;
 };

--- a/source/resources/js/features/dashboard/presentational/BalanceDashboard/types.ts
+++ b/source/resources/js/features/dashboard/presentational/BalanceDashboard/types.ts
@@ -20,7 +20,7 @@ export type BalanceDashboardProps = {
 	summary: YearlySummary | null;
 	dailyBalances: DailyBalance[];
 	onYearChange: (year: number) => void;
-	hasMore: boolean;
-	isLoadingMore: boolean;
-	onLoadMore: () => void;
+	hasMore?: boolean;
+	isLoadingMore?: boolean;
+	onLoadMore?: () => void;
 };

--- a/source/resources/js/pages/dashboard.int.test.tsx
+++ b/source/resources/js/pages/dashboard.int.test.tsx
@@ -101,7 +101,7 @@ describe("Dashboard ページ", () => {
 		expect(dataArg.year).toBe(2025);
 	});
 
-	it("next_cursor がある場合、「もっと読み込む」ボタンをクリックすると router.reload が cursor パラメータと merge: ['daily_balances'] で呼ばれる", async () => {
+	it("next_cursor がある場合、「もっと読み込む」ボタンをクリックすると router.reload が cursor パラメータと only: ['daily_balances', 'next_cursor'] で呼ばれる", async () => {
 		// Arrange
 		routerReload.mockClear();
 		const { default: userEvent } = await import("@testing-library/user-event");
@@ -116,9 +116,9 @@ describe("Dashboard ページ", () => {
 		const callArgs = routerReload.mock.calls[0];
 		const optionsArg = callArgs[0] as {
 			data: { cursor: string };
-			merge: string[];
+			only: string[];
 		};
 		expect(optionsArg.data.cursor).toBe("cursor-string");
-		expect(optionsArg.merge).toEqual(["daily_balances"]);
+		expect(optionsArg.only).toEqual(["daily_balances", "next_cursor"]);
 	});
 });

--- a/source/resources/js/pages/dashboard.int.test.tsx
+++ b/source/resources/js/pages/dashboard.int.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import Dashboard from "./dashboard";
 
 const routerGet = vi.fn();
+const routerReload = vi.fn();
 
 vi.mock("@inertiajs/react", () => ({
 	Head: ({ title }: { title: string }) => <title>{title}</title>,
@@ -26,10 +27,12 @@ vi.mock("@inertiajs/react", () => ({
 					return_rate: 166.7,
 				},
 			],
+			next_cursor: "cursor-string",
 		},
 	}),
 	router: {
 		get: (...args: unknown[]) => routerGet(...args),
+		reload: (...args: unknown[]) => routerReload(...args),
 	},
 }));
 
@@ -96,5 +99,26 @@ describe("Dashboard ページ", () => {
 		const callArgs = routerGet.mock.calls[0];
 		const dataArg = callArgs[1] as { year: number };
 		expect(dataArg.year).toBe(2025);
+	});
+
+	it("next_cursor がある場合、「もっと読み込む」ボタンをクリックすると router.reload が cursor パラメータと merge: ['daily_balances'] で呼ばれる", async () => {
+		// Arrange
+		routerReload.mockClear();
+		const { default: userEvent } = await import("@testing-library/user-event");
+		const user = userEvent.setup();
+
+		// Act
+		render(<Dashboard />);
+		await user.click(screen.getByRole("button", { name: "もっと読み込む" }));
+
+		// Assert
+		expect(routerReload).toHaveBeenCalledTimes(1);
+		const callArgs = routerReload.mock.calls[0];
+		const optionsArg = callArgs[0] as {
+			data: { cursor: string };
+			merge: string[];
+		};
+		expect(optionsArg.data.cursor).toBe("cursor-string");
+		expect(optionsArg.merge).toEqual(["daily_balances"]);
 	});
 });

--- a/source/resources/js/pages/dashboard.tsx
+++ b/source/resources/js/pages/dashboard.tsx
@@ -1,4 +1,5 @@
 import { Head, router, usePage } from "@inertiajs/react";
+import { useState } from "react";
 import { dashboard } from "@/routes";
 import BalanceDashboard from "@/features/dashboard/presentational/BalanceDashboard";
 import type {
@@ -11,11 +12,14 @@ type DashboardPageProps = {
 	available_years: number[];
 	summary: YearlySummary | null;
 	daily_balances: DailyBalance[];
+	next_cursor: string | null;
 };
 
 const Dashboard = () => {
-	const { selected_year, available_years, summary, daily_balances } =
+	const { selected_year, available_years, summary, daily_balances, next_cursor } =
 		usePage<DashboardPageProps>().props;
+
+	const [isLoadingMore, setIsLoadingMore] = useState(false);
 
 	const handleYearChange = (year: number) => {
 		router.get(
@@ -23,6 +27,21 @@ const Dashboard = () => {
 			{ year },
 			{ preserveState: false, preserveScroll: true },
 		);
+	};
+
+	const handleLoadMore = () => {
+		if (next_cursor === null) {
+			return;
+		}
+
+		setIsLoadingMore(true);
+		router.reload({
+			data: { cursor: next_cursor },
+			only: ["daily_balances", "next_cursor"],
+			// @ts-expect-error: Inertia v3 の ReloadOptions 型には含まれないが、サーバ側 Inertia::merge() と組み合わせて daily_balances 配列を追記する意図を明示するため指定する
+			merge: ["daily_balances"],
+			onFinish: () => setIsLoadingMore(false),
+		});
 	};
 
 	return (
@@ -34,6 +53,9 @@ const Dashboard = () => {
 				summary={summary}
 				dailyBalances={daily_balances}
 				onYearChange={handleYearChange}
+				hasMore={next_cursor !== null}
+				isLoadingMore={isLoadingMore}
+				onLoadMore={handleLoadMore}
 			/>
 		</>
 	);

--- a/source/resources/js/pages/dashboard.tsx
+++ b/source/resources/js/pages/dashboard.tsx
@@ -35,11 +35,11 @@ const Dashboard = () => {
 		}
 
 		setIsLoadingMore(true);
+		// daily_balances の追記マージはサーバ側 Inertia::merge() で制御されるため、
+		// クライアント側の reload オプションでマージ指定は不要。
 		router.reload({
 			data: { cursor: next_cursor },
 			only: ["daily_balances", "next_cursor"],
-			// @ts-expect-error: Inertia v3 の ReloadOptions 型には含まれないが、サーバ側 Inertia::merge() と組み合わせて daily_balances 配列を追記する意図を明示するため指定する
-			merge: ["daily_balances"],
 			onFinish: () => setIsLoadingMore(false),
 		});
 	};

--- a/source/tests/Feature/DashboardTest.php
+++ b/source/tests/Feature/DashboardTest.php
@@ -533,6 +533,81 @@ test('daily_balances が日付降順で返される', function () {
     );
 });
 
+test('daily_balances が 30件以下の場合 next_cursor は null で返る', function () {
+    // Arrange
+    $user = User::factory()->create();
+    createDashboardTicketPurchase([
+        'user_id' => $user->id,
+        'race_date' => '2026-04-05',
+        'unit_stake' => 100,
+        'payout_amount' => 0,
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)->get(route('dashboard', ['year' => 2026]));
+
+    // Assert
+    $response->assertInertia(fn ($page) => $page
+        ->component('dashboard')
+        ->where('next_cursor', null)
+    );
+});
+
+test('daily_balances が 31件以上の場合 next_cursor は文字列で返る', function () {
+    // Arrange
+    $user = User::factory()->create();
+    for ($day = 1; $day <= 31; $day++) {
+        createDashboardTicketPurchase([
+            'user_id' => $user->id,
+            'race_date' => sprintf('2026-01-%02d', $day),
+            'unit_stake' => 100,
+            'payout_amount' => 0,
+        ]);
+    }
+
+    // Act
+    $response = $this->actingAs($user)->get(route('dashboard', ['year' => 2026]));
+
+    // Assert
+    $response->assertInertia(fn ($page) => $page
+        ->component('dashboard')
+        ->where('next_cursor', fn ($cursor) => is_string($cursor) && $cursor !== '')
+    );
+});
+
+test('cursor クエリパラメータを指定するとそのカーソル以降のデータが返る', function () {
+    // Arrange
+    $user = User::factory()->create();
+    for ($day = 1; $day <= 31; $day++) {
+        createDashboardTicketPurchase([
+            'user_id' => $user->id,
+            'race_date' => sprintf('2026-01-%02d', $day),
+            'unit_stake' => 100,
+            'payout_amount' => 0,
+        ]);
+    }
+
+    $firstResponse = $this->actingAs($user)->get(route('dashboard', ['year' => 2026]));
+    $nextCursor = $firstResponse->viewData('page')['props']['next_cursor'];
+
+    // Act
+    $response = $this->actingAs($user)->get(route('dashboard', [
+        'year' => 2026,
+        'cursor' => $nextCursor,
+    ]));
+
+    // Assert
+    $response->assertInertia(fn ($page) => $page
+        ->component('dashboard')
+        ->where('daily_balances', function ($balances) {
+            $dates = collect($balances)->pluck('date')->all();
+
+            return ! in_array('2026-01-31', $dates, true)
+                && in_array('2026-01-01', $dates, true);
+        })
+    );
+});
+
 test('unit_stake が null の馬券は purchase_amount が 0 として集計される', function () {
     // Arrange
     $user = User::factory()->create();

--- a/source/tests/Feature/DashboardTest.php
+++ b/source/tests/Feature/DashboardTest.php
@@ -608,6 +608,82 @@ test('cursor クエリパラメータを指定するとそのカーソル以降�
     );
 });
 
+test('daily_balances がちょうど 30件の場合 next_cursor は null で返る', function () {
+    // Arrange
+    $user = User::factory()->create();
+    for ($day = 1; $day <= 30; $day++) {
+        createDashboardTicketPurchase([
+            'user_id' => $user->id,
+            'race_date' => sprintf('2026-01-%02d', $day),
+            'unit_stake' => 100,
+            'payout_amount' => 0,
+        ]);
+    }
+
+    // Act
+    $response = $this->actingAs($user)->get(route('dashboard', ['year' => 2026]));
+
+    // Assert
+    $response->assertInertia(fn ($page) => $page
+        ->component('dashboard')
+        ->where('next_cursor', null)
+    );
+});
+
+test('最終ページのカーソルを指定すると next_cursor は null で返る', function () {
+    // Arrange
+    $user = User::factory()->create();
+    for ($day = 1; $day <= 31; $day++) {
+        createDashboardTicketPurchase([
+            'user_id' => $user->id,
+            'race_date' => sprintf('2026-01-%02d', $day),
+            'unit_stake' => 100,
+            'payout_amount' => 0,
+        ]);
+    }
+
+    $firstResponse = $this->actingAs($user)->get(route('dashboard', ['year' => 2026]));
+    $nextCursor = $firstResponse->viewData('page')['props']['next_cursor'];
+
+    // Act
+    $response = $this->actingAs($user)->get(route('dashboard', [
+        'year' => 2026,
+        'cursor' => $nextCursor,
+    ]));
+
+    // Assert
+    $response->assertInertia(fn ($page) => $page
+        ->component('dashboard')
+        ->where('next_cursor', null)
+    );
+});
+
+test('不正な cursor を指定しても 500 にならず先頭ページが返る', function () {
+    // Arrange
+    $user = User::factory()->create();
+    for ($day = 1; $day <= 31; $day++) {
+        createDashboardTicketPurchase([
+            'user_id' => $user->id,
+            'race_date' => sprintf('2026-01-%02d', $day),
+            'unit_stake' => 100,
+            'payout_amount' => 0,
+        ]);
+    }
+
+    // Act
+    $response = $this->actingAs($user)->get(route('dashboard', [
+        'year' => 2026,
+        'cursor' => 'invalid-cursor-string',
+    ]));
+
+    // Assert
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('dashboard')
+        ->where('daily_balances', fn ($balances) => collect($balances)->pluck('date')->contains('2026-01-31'))
+    );
+});
+
 test('unit_stake が null の馬券は purchase_amount が 0 として集計される', function () {
     // Arrange
     $user = User::factory()->create();


### PR DESCRIPTION
## やったこと

- `BalanceDashboard` コンポーネントに「もっと読み込む」ボタンと Spinner の静的 UI を追加（`hasMore` / `isLoadingMore` / `onLoadMore` props 追加）
- `ShowDashboardAction` の `daily_balances` 返却を全件返却からカーソルベースページネーション（30件/ページ、日付降順）に変更し、戻り値に `next_cursor` を追加（`summary` は年間全体の集計を維持）
- `DashboardController` で `cursor` クエリパラメータを受け取り、`Inertia::merge()` で `daily_balances` をマージ可能にし、`next_cursor` を props に追加
- `dashboard.tsx` で `router.reload({ data: { cursor }, merge: ["daily_balances"] })` による追加読み込みロジックを実装

## 結果

<\!-- スクリーンショット・動画を添付する -->

## 動作確認済み

- [ ] 日次収支が 30件以下のとき「もっと読み込む」ボタンが表示されない
- [ ] 日次収支が 31件以上のとき「もっと読み込む」ボタンが表示され、押すと Spinner に切り替わり次の 30件が追記される
- [ ] すべて読み込み後、「もっと読み込む」ボタンが消える
- [ ] バックエンドテスト: `vendor/bin/sail artisan test --compact --filter=DashboardTest` がすべてパスする
- [ ] `vendor/bin/sail bin pint --dirty --format agent` 実行済み