### PR TITLE
[minor] Spectator を導入して OpenAPI と Laravel API レスポンスの突合テストを追加

### DIFF
--- a/.claude/rules/testing-backend.md
+++ b/.claude/rules/testing-backend.md
@@ -48,3 +48,34 @@ Arrangeのないテスト（画面表示確認など）はActとAssertのみコ�
 | 外部サービス（メール等） | Laravelの Fake 機能（`Mail::fake()` 等）でモックする |
 
 GitHub Actions では MySQL サービスコンテナが起動済みのため、`RefreshDatabase` はCIでそのまま動作する。
+
+## 契約テスト（OpenAPI ↔ API レスポンスの突合）
+
+API エンドポイントを新規追加、またはリクエスト/レスポンス構造を変更した場合は、`tests/Feature/Contract/` に Spectator を使った契約テストを1本追加する（happy-path のみ）。`docs/specs/openapi.yaml` の更新と必ずセットで行う。
+
+- 配置: `tests/Feature/Contract/<Resource>ContractTest.php`
+- 1ファイル1リソース、1エンドポイントにつき1テストで happy-path のみカバーする
+- 雛形:
+
+```php
+use Spectator\Spectator;
+
+beforeEach(function () {
+    Spectator::using('openapi.yaml');
+});
+
+test('contract: <operationId> matches OpenAPI spec', function () {
+    // Arrange
+    $user = User::factory()->create();
+    // ... エンドポイントが要求する最小構成のデータを用意
+
+    // Act
+    $response = $this->actingAs($user)->getJson('/api/...');
+
+    // Assert
+    $response->assertValidRequest()->assertValidResponse(200);
+});
+```
+
+- 既存例: `tests/Feature/Contract/RaceMarkColumnContractTest.php`
+- 異常系（401/403/404/422）の契約検証はスコープ外。必要になったタイミングで追加する

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -6,6 +6,7 @@ on:
       - 'source/**/*.php'
       - 'source/composer.json'
       - 'source/composer.lock'
+      - 'docs/specs/openapi.yaml'
 
 jobs:
   pest:

--- a/source/composer.json
+++ b/source/composer.json
@@ -18,6 +18,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
+        "hotmeteor/spectator": "^3.0",
         "laravel/boost": "^2.4",
         "laravel/pail": "^1.2.5",
         "laravel/pint": "^1.27",

--- a/source/composer.lock
+++ b/source/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d097f17d9573e5870ceaf623b53ff065",
+    "content-hash": "7c71afe957c69285e45ce86deadae447",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -6579,6 +6579,75 @@
             "time": "2026-03-09T14:33:17+00:00"
         },
         {
+            "name": "cebe/php-openapi",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cebe/php-openapi.git",
+                "reference": "893ab104be1f5dfe5a39766703f583584e43c6e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cebe/php-openapi/zipball/893ab104be1f5dfe5a39766703f583584e43c6e1",
+                "reference": "893ab104be1f5dfe5a39766703f583584e43c6e1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "justinrainbow/json-schema": "^5.2 || ^6.0",
+                "php": ">=7.1.0",
+                "symfony/yaml": "^3.4 || ^4 || ^5 || ^6 || ^7.0"
+            },
+            "conflict": {
+                "symfony/yaml": "3.4.0 - 3.4.4 || 4.0.0 - 4.4.17 || 5.0.0 - 5.1.9 || 5.2.0"
+            },
+            "require-dev": {
+                "apis-guru/openapi-directory": "1.0.0",
+                "cebe/indent": "*",
+                "mermade/openapi3-examples": "1.0.0",
+                "nexmo/api-specification": "1.0.0",
+                "oai/openapi-specification": "3.0.3",
+                "phpstan/phpstan": "^0.12.0 || ^1.9",
+                "phpunit/phpunit": "^6.5 || ^7.5 || ^8.5 || ^9.4"
+            },
+            "bin": [
+                "bin/php-openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "cebe\\openapi\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Carsten Brandt",
+                    "email": "mail@cebe.cc",
+                    "homepage": "https://cebe.cc/",
+                    "role": "Creator"
+                }
+            ],
+            "description": "Read and write OpenAPI yaml/json files and make the content accessable in PHP objects.",
+            "homepage": "https://github.com/cebe/php-openapi#readme",
+            "keywords": [
+                "openapi"
+            ],
+            "support": {
+                "issues": "https://github.com/cebe/php-openapi/issues",
+                "source": "https://github.com/cebe/php-openapi"
+            },
+            "time": "2025-05-07T08:44:12+00:00"
+        },
+        {
             "name": "doctrine/deprecations",
             "version": "1.1.6",
             "source": {
@@ -6873,6 +6942,87 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
+            "name": "hotmeteor/spectator",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hotmeteor/spectator.git",
+                "reference": "429da34ebba351329c4ca3ba62c9c5b621f9b6fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hotmeteor/spectator/zipball/429da34ebba351329c4ca3ba62c9c5b621f9b6fb",
+                "reference": "429da34ebba351329c4ca3ba62c9c5b621f9b6fb",
+                "shasum": ""
+            },
+            "require": {
+                "cebe/php-openapi": "^1.8",
+                "ext-json": "*",
+                "laravel/framework": ">=12.0",
+                "opis/json-schema": "^2.3",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "larastan/larastan": ">=3.0",
+                "laravel/pint": "^1.13",
+                "nunomaduro/collision": ">=8.0",
+                "orchestra/testbench": ">=10.0",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spectator\\SpectatorServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spectator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Adam Campbell",
+                    "email": "adam@hotmeteor.com"
+                }
+            ],
+            "description": "Testing helpers for your OpenAPI spec",
+            "keywords": [
+                "laravel",
+                "openapi",
+                "spectator",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/hotmeteor/spectator/issues",
+                "source": "https://github.com/hotmeteor/spectator/tree/v3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/bastien-phi",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/hotmeteor",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jarrodparkes",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-01T00:14:25+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "2.1.1",
             "source": {
@@ -6931,6 +7081,81 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "6.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jsonrainbow/json-schema.git",
+                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2c89ebb95ca9cedc9347f780333f7b25792dcb76",
+                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "marc-mabe/php-enum": "^4.4",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.3.0",
+                "json-schema/json-schema-test-suite": "dev-main",
+                "marc-mabe/php-enum-phpstan": "^2.0",
+                "phpspec/prophecy": "^1.19",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^8.5"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/jsonrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/jsonrainbow/json-schema/issues",
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.8.2"
+            },
+            "time": "2026-05-05T05:39:01+00:00"
         },
         {
             "name": "laravel/boost",
@@ -7344,6 +7569,79 @@
             "time": "2026-03-23T15:56:34+00:00"
         },
         {
+            "name": "marc-mabe/php-enum",
+            "version": "v4.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/marc-mabe/php-enum.git",
+                "reference": "bb426fcdd65c60fb3638ef741e8782508fda7eef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marc-mabe/php-enum/zipball/bb426fcdd65c60fb3638ef741e8782508fda7eef",
+                "reference": "bb426fcdd65c60fb3638ef741e8782508fda7eef",
+                "shasum": ""
+            },
+            "require": {
+                "ext-reflection": "*",
+                "php": "^7.1 | ^8.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.16.10 || ^1.0.4",
+                "phpstan/phpstan": "^1.3.1",
+                "phpunit/phpunit": "^7.5.20 | ^8.5.22 | ^9.5.11",
+                "vimeo/psalm": "^4.17.0 | ^5.26.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.2-dev",
+                    "dev-master": "4.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MabeEnum\\": "src/"
+                },
+                "classmap": [
+                    "stubs/Stringable.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marc Bennewitz",
+                    "email": "dev@mabe.berlin",
+                    "homepage": "https://mabe.berlin/",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Simple and fast implementation of enumerations with native PHP",
+            "homepage": "https://github.com/marc-mabe/php-enum",
+            "keywords": [
+                "enum",
+                "enum-map",
+                "enum-set",
+                "enumeration",
+                "enumerator",
+                "enummap",
+                "enumset",
+                "map",
+                "set",
+                "type",
+                "type-hint",
+                "typehint"
+            ],
+            "support": {
+                "issues": "https://github.com/marc-mabe/php-enum/issues",
+                "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.2"
+            },
+            "time": "2025-09-14T11:18:39+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.6.12",
             "source": {
@@ -7581,6 +7879,196 @@
                 }
             ],
             "time": "2026-02-17T17:33:08+00:00"
+        },
+        {
+            "name": "opis/json-schema",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/json-schema.git",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/json-schema/zipball/8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "opis/string": "^2.1",
+                "opis/uri": "^1.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                },
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                }
+            ],
+            "description": "Json Schema Validator for PHP",
+            "homepage": "https://opis.io/json-schema",
+            "keywords": [
+                "json",
+                "json-schema",
+                "schema",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/json-schema/issues",
+                "source": "https://github.com/opis/json-schema/tree/2.6.0"
+            },
+            "time": "2025-10-17T12:46:48+00:00"
+        },
+        {
+            "name": "opis/string",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/string.git",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/string/zipball/3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\String\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Multibyte strings as objects",
+            "homepage": "https://opis.io/string",
+            "keywords": [
+                "multi-byte",
+                "opis",
+                "string",
+                "string manipulation",
+                "utf-8"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/string/issues",
+                "source": "https://github.com/opis/string/tree/2.1.0"
+            },
+            "time": "2025-10-17T12:38:41+00:00"
+        },
+        {
+            "name": "opis/uri",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/uri.git",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/uri/zipball/0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "shasum": ""
+            },
+            "require": {
+                "opis/string": "^2.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Build, parse and validate URIs and URI-templates",
+            "homepage": "https://opis.io",
+            "keywords": [
+                "URI Template",
+                "parse url",
+                "punycode",
+                "uri",
+                "uri components",
+                "url",
+                "validate uri"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/uri/issues",
+                "source": "https://github.com/opis/uri/tree/1.1.0"
+            },
+            "time": "2021-05-22T15:57:08+00:00"
         },
         {
             "name": "pestphp/pest",
@@ -9996,5 +10484,5 @@
         "php": "^8.3"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/source/config/spectator.php
+++ b/source/config/spectator.php
@@ -1,0 +1,66 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Default Spec Source
+    |--------------------------------------------------------------------------
+    */
+
+    'default' => env('SPEC_SOURCE', 'local'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sources
+    |--------------------------------------------------------------------------
+    */
+
+    'sources' => [
+        'local' => [
+            'source' => 'local',
+            'base_path' => env('SPEC_PATH', base_path('../docs/specs')),
+        ],
+
+        'remote' => [
+            'source' => 'remote',
+            'base_path' => env('SPEC_PATH'),
+            'params' => env('SPEC_URL_PARAMS', ''),
+        ],
+
+        'github' => [
+            'source' => 'github',
+            'base_path' => env('SPEC_GITHUB_PATH'),
+            'repo' => env('SPEC_GITHUB_REPO'),
+            'token' => env('SPEC_GITHUB_TOKEN'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Paths
+    |--------------------------------------------------------------------------
+    */
+
+    'path_prefix' => '',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Error Format
+    |--------------------------------------------------------------------------
+    */
+
+    'error_format' => env('SPECTATOR_ERROR_FORMAT', 'text'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Middleware Groups
+    |--------------------------------------------------------------------------
+    |
+    | API routes in this project are defined under routes/web.php with an
+    | `api/` URL prefix, so Spectator's middleware must be attached to the
+    | `web` group rather than the framework default `api`.
+    |
+    */
+
+    'middleware_groups' => ['web'],
+];

--- a/source/tests/Feature/Contract/RaceMarkColumnContractTest.php
+++ b/source/tests/Feature/Contract/RaceMarkColumnContractTest.php
@@ -1,0 +1,218 @@
+<?php
+
+use App\Models\Race;
+use App\Models\RaceMarkColumn;
+use App\Models\User;
+use App\Models\Venue;
+use Illuminate\Support\Facades\DB;
+use Spectator\Spectator;
+
+beforeEach(function () {
+    Spectator::using('openapi.yaml');
+});
+
+/**
+ * 契約テスト用の race を 1 件作成する
+ */
+function createRaceForContractTest(int $raceNumber): Race
+{
+    $venue = Venue::firstOrCreate(['name' => '東京']);
+
+    return Race::create([
+        'venue_id' => $venue->id,
+        'race_date' => '2026-04-26',
+        'race_number' => $raceNumber,
+    ]);
+}
+
+/**
+ * race_entries に 1 件挿入して ID を返す
+ */
+function insertRaceEntryForContractTest(int $raceId): int
+{
+    $now = now();
+    $horseId = DB::table('horses')->insertGetId([
+        'name' => '契約テスト用ホース'.uniqid(),
+        'birth_year' => 2022,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+    $jockeyId = DB::table('jockeys')->insertGetId([
+        'name' => '契約テスト用騎手'.uniqid(),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    return DB::table('race_entries')->insertGetId([
+        'race_id' => $raceId,
+        'horse_id' => $horseId,
+        'jockey_id' => $jockeyId,
+        'frame_number' => 1,
+        'horse_number' => 1,
+        'weight' => 55.0,
+        'horse_weight' => 480,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+}
+
+// ===== GET /api/races/{uid}/mark-columns =====
+
+test('contract: GET listRaceMarkColumns matches OpenAPI spec', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $race = createRaceForContractTest(1);
+
+    // Act
+    $response = $this->actingAs($user)
+        ->getJson('/api/races/'.$race->uid.'/mark-columns');
+
+    // Assert
+    $response->assertValidRequest()->assertValidResponse(200);
+});
+
+// ===== POST /api/races/{uid}/mark-columns =====
+
+test('contract: POST createOtherRaceMarkColumn matches OpenAPI spec', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $race = createRaceForContractTest(2);
+
+    // Act
+    $response = $this->actingAs($user)
+        ->postJson('/api/races/'.$race->uid.'/mark-columns', [
+            'label' => '友人A',
+        ]);
+
+    // Assert
+    $response->assertValidRequest()->assertValidResponse(201);
+});
+
+// ===== PATCH /api/races/{uid}/mark-columns/{id} =====
+
+test('contract: PATCH updateRaceMarkColumnLabel matches OpenAPI spec', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $race = createRaceForContractTest(3);
+    $column = RaceMarkColumn::factory()
+        ->other()
+        ->create([
+            'race_id' => $race->id,
+            'user_id' => $user->id,
+            'label' => '旧ラベル',
+            'display_order' => 1,
+        ]);
+
+    // Act
+    $response = $this->actingAs($user)
+        ->patchJson('/api/races/'.$race->uid.'/mark-columns/'.$column->id, [
+            'label' => '新ラベル',
+        ]);
+
+    // Assert
+    $response->assertValidRequest()->assertValidResponse(200);
+});
+
+// ===== DELETE /api/races/{uid}/mark-columns/{id} =====
+
+test('contract: DELETE deleteRaceMarkColumn matches OpenAPI spec', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $race = createRaceForContractTest(4);
+    $column = RaceMarkColumn::factory()
+        ->other()
+        ->create([
+            'race_id' => $race->id,
+            'user_id' => $user->id,
+            'label' => '削除対象',
+            'display_order' => 1,
+        ]);
+
+    // Act
+    $response = $this->actingAs($user)
+        ->deleteJson('/api/races/'.$race->uid.'/mark-columns/'.$column->id);
+
+    // Assert
+    $response->assertValidRequest()->assertValidResponse(204);
+});
+
+// ===== PUT /api/races/{uid}/mark-columns/{column_id}/entries/{race_entry_id}/mark =====
+
+test('contract: PUT putRaceMark matches OpenAPI spec', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $race = createRaceForContractTest(5);
+    $column = RaceMarkColumn::factory()
+        ->own()
+        ->create([
+            'race_id' => $race->id,
+            'user_id' => $user->id,
+        ]);
+    $raceEntryId = insertRaceEntryForContractTest($race->id);
+
+    // Act
+    $response = $this->actingAs($user)
+        ->putJson('/api/races/'.$race->uid.'/mark-columns/'.$column->id.'/entries/'.$raceEntryId.'/mark', [
+            'mark_value' => '◎',
+        ]);
+
+    // Assert
+    $response->assertValidRequest()->assertValidResponse(200);
+});
+
+// ===== PUT /api/races/{uid}/mark-columns/{column_id}/entries/{race_entry_id}/memo =====
+
+test('contract: PUT putRaceMarkMemo matches OpenAPI spec', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $race = createRaceForContractTest(6);
+    $column = RaceMarkColumn::factory()
+        ->other()
+        ->create([
+            'race_id' => $race->id,
+            'user_id' => $user->id,
+            'label' => '他人の列',
+            'display_order' => 1,
+        ]);
+    $raceEntryId = insertRaceEntryForContractTest($race->id);
+
+    // Act
+    $response = $this->actingAs($user)
+        ->putJson('/api/races/'.$race->uid.'/mark-columns/'.$column->id.'/entries/'.$raceEntryId.'/memo', [
+            'content' => '契約テストメモ',
+        ]);
+
+    // Assert
+    $response->assertValidRequest()->assertValidResponse(201);
+});
+
+// ===== DELETE /api/races/{uid}/mark-columns/{column_id}/entries/{race_entry_id}/memo =====
+
+test('contract: DELETE deleteRaceMarkMemo matches OpenAPI spec', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $race = createRaceForContractTest(7);
+    $column = RaceMarkColumn::factory()
+        ->other()
+        ->create([
+            'race_id' => $race->id,
+            'user_id' => $user->id,
+            'label' => '他人の列',
+            'display_order' => 1,
+        ]);
+    $raceEntryId = insertRaceEntryForContractTest($race->id);
+    DB::table('race_mark_memos')->insert([
+        'race_mark_column_id' => $column->id,
+        'race_entry_id' => $raceEntryId,
+        'content' => '削除対象メモ',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // Act
+    $response = $this->actingAs($user)
+        ->deleteJson('/api/races/'.$race->uid.'/mark-columns/'.$column->id.'/entries/'.$raceEntryId.'/memo');
+
+    // Assert
+    $response->assertValidRequest()->assertValidResponse(204);
+});


### PR DESCRIPTION
## やったこと

- `hotmeteor/spectator` v3.0.2 を devDependency として導入
- `config/spectator.php` を追加（OpenAPI YAML パスとして `../docs/specs`、ミドルウェアグループを `web` に設定）
- `tests/Feature/Contract/RaceMarkColumnContractTest.php` を新規作成し、mark-columns 系 7 エンドポイントの OpenAPI ↔ レスポンス突合テストを追加
- `pest.yml` の CI トリガーに `docs/specs/openapi.yaml` を追加（仕様変更時にも CI が発火するように）

## 結果

スクリーンショット・動画なし（テストコードの追加のみ）

## 動作確認済み

- [x] 契約テスト 7 本グリーン（`--filter=Contract`）
- [x] 既存 mark-columns 系テスト 53 本も引き続きグリーン（リグレッションなし）
- [x] OpenAPI の `label` 型を意図的に `integer` へ変更したとき、対象テストが FAIL することを確認（乖離検知が機能する）