### PR TITLE
[patch] テストの @inertiajs/react モック定義を共通ヘルパーに集約

### DIFF
--- a/source/resources/js/features/raceEntry/containers/RaceEntryAddFormContainer/RaceEntryAddFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceEntry/containers/RaceEntryAddFormContainer/RaceEntryAddFormContainer.int.test.tsx
@@ -1,22 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInertiaCoreMock } from "@/tests/mocks";
 import RaceEntryAddFormContainer from "./index";
 
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return {
-		...actual,
-		router: {
-			post: vi.fn(),
-			put: vi.fn(),
-			patch: vi.fn(),
-			delete: vi.fn(),
-			visit: vi.fn(),
-			reload: vi.fn(),
-		},
-	};
+	return createInertiaCoreMock(actual);
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/features/raceEntry/containers/RaceEntryAddFormContainer/RaceEntryAddFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceEntry/containers/RaceEntryAddFormContainer/RaceEntryAddFormContainer.int.test.tsx
@@ -7,7 +7,7 @@ import RaceEntryAddFormContainer from "./index";
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return createInertiaCoreMock(actual);
+	return createInertiaCoreMock({ actual });
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/features/raceEntry/containers/RaceEntryEditFormContainer/RaceEntryEditFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceEntry/containers/RaceEntryEditFormContainer/RaceEntryEditFormContainer.int.test.tsx
@@ -7,7 +7,7 @@ import RaceEntryEditFormContainer from "./index";
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return createInertiaCoreMock(actual);
+	return createInertiaCoreMock({ actual });
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/features/raceEntry/containers/RaceEntryEditFormContainer/RaceEntryEditFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceEntry/containers/RaceEntryEditFormContainer/RaceEntryEditFormContainer.int.test.tsx
@@ -1,22 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInertiaCoreMock } from "@/tests/mocks";
 import RaceEntryEditFormContainer from "./index";
 
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return {
-		...actual,
-		router: {
-			post: vi.fn(),
-			put: vi.fn(),
-			patch: vi.fn(),
-			delete: vi.fn(),
-			visit: vi.fn(),
-			reload: vi.fn(),
-		},
-	};
+	return createInertiaCoreMock(actual);
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/features/raceEntry/containers/RaceEntryRegistrationFormContainer/RaceEntryRegistrationFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceEntry/containers/RaceEntryRegistrationFormContainer/RaceEntryRegistrationFormContainer.int.test.tsx
@@ -1,22 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInertiaCoreMock } from "@/tests/mocks";
 import RaceEntryRegistrationFormContainer from "./index";
 
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return {
-		...actual,
-		router: {
-			post: vi.fn(),
-			put: vi.fn(),
-			patch: vi.fn(),
-			delete: vi.fn(),
-			visit: vi.fn(),
-			reload: vi.fn(),
-		},
-	};
+	return createInertiaCoreMock(actual);
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/features/raceEntry/containers/RaceEntryRegistrationFormContainer/RaceEntryRegistrationFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceEntry/containers/RaceEntryRegistrationFormContainer/RaceEntryRegistrationFormContainer.int.test.tsx
@@ -7,7 +7,7 @@ import RaceEntryRegistrationFormContainer from "./index";
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return createInertiaCoreMock(actual);
+	return createInertiaCoreMock({ actual });
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/features/raceInput/containers/RaceInputFormContainer/RaceInputFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceInput/containers/RaceInputFormContainer/RaceInputFormContainer.int.test.tsx
@@ -7,7 +7,7 @@ import RaceInputFormContainer from "./index";
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return createInertiaCoreMock(actual);
+	return createInertiaCoreMock({ actual });
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/features/raceInput/containers/RaceInputFormContainer/RaceInputFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceInput/containers/RaceInputFormContainer/RaceInputFormContainer.int.test.tsx
@@ -1,22 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInertiaCoreMock } from "@/tests/mocks";
 import RaceInputFormContainer from "./index";
 
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return {
-		...actual,
-		router: {
-			post: vi.fn(),
-			put: vi.fn(),
-			patch: vi.fn(),
-			delete: vi.fn(),
-			visit: vi.fn(),
-			reload: vi.fn(),
-		},
-	};
+	return createInertiaCoreMock(actual);
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/features/raceResult/containers/RaceResultFormContainer/RaceResultFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceResult/containers/RaceResultFormContainer/RaceResultFormContainer.int.test.tsx
@@ -7,7 +7,7 @@ import RaceResultFormContainer from "./index";
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return createInertiaCoreMock(actual);
+	return createInertiaCoreMock({ actual });
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/features/raceResult/containers/RaceResultFormContainer/RaceResultFormContainer.int.test.tsx
+++ b/source/resources/js/features/raceResult/containers/RaceResultFormContainer/RaceResultFormContainer.int.test.tsx
@@ -1,22 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInertiaCoreMock } from "@/tests/mocks";
 import RaceResultFormContainer from "./index";
 
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return {
-		...actual,
-		router: {
-			post: vi.fn(),
-			put: vi.fn(),
-			patch: vi.fn(),
-			delete: vi.fn(),
-			visit: vi.fn(),
-			reload: vi.fn(),
-		},
-	};
+	return createInertiaCoreMock(actual);
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/features/ticket/containers/TicketPurchaseFormContainer/TicketPurchaseFormContainer.int.test.tsx
+++ b/source/resources/js/features/ticket/containers/TicketPurchaseFormContainer/TicketPurchaseFormContainer.int.test.tsx
@@ -7,7 +7,7 @@ import TicketPurchaseFormContainer from "./index";
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return createInertiaCoreMock(actual);
+	return createInertiaCoreMock({ actual });
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/features/ticket/containers/TicketPurchaseFormContainer/TicketPurchaseFormContainer.int.test.tsx
+++ b/source/resources/js/features/ticket/containers/TicketPurchaseFormContainer/TicketPurchaseFormContainer.int.test.tsx
@@ -1,22 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInertiaCoreMock } from "@/tests/mocks";
 import TicketPurchaseFormContainer from "./index";
 
 vi.mock("@inertiajs/core", async () => {
 	const actual =
 		await vi.importActual<typeof import("@inertiajs/core")>("@inertiajs/core");
-	return {
-		...actual,
-		router: {
-			post: vi.fn(),
-			put: vi.fn(),
-			patch: vi.fn(),
-			delete: vi.fn(),
-			visit: vi.fn(),
-			reload: vi.fn(),
-		},
-	};
+	return createInertiaCoreMock(actual);
 });
 
 import { router } from "@inertiajs/core";

--- a/source/resources/js/pages/dashboard.int.test.tsx
+++ b/source/resources/js/pages/dashboard.int.test.tsx
@@ -1,40 +1,41 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createInertiaReactMock } from "@/tests/mocks";
 import Dashboard from "./dashboard";
 
-const routerGet = vi.fn();
-const routerReload = vi.fn();
-
-vi.mock("@inertiajs/react", () => ({
-	Head: ({ title }: { title: string }) => <title>{title}</title>,
-	usePage: () => ({
-		props: {
-			selected_year: 2026,
-			available_years: [2025, 2026],
-			summary: {
-				year: 2026,
-				total_purchase_amount: 50000,
-				total_payout_amount: 45000,
-				total_net_amount: -5000,
-				total_return_rate: 90.0,
-			},
-			daily_balances: [
-				{
-					date: "2026-04-05",
-					purchase_amount: 3000,
-					payout_amount: 5000,
-					net_amount: 2000,
-					return_rate: 166.7,
-				},
-			],
-			next_cursor: "cursor-string",
-		},
-	}),
-	router: {
-		get: (...args: unknown[]) => routerGet(...args),
-		reload: (...args: unknown[]) => routerReload(...args),
-	},
+const { routerGet, routerReload } = vi.hoisted(() => ({
+	routerGet: vi.fn(),
+	routerReload: vi.fn(),
 }));
+
+vi.mock("@inertiajs/react", () =>
+	createInertiaReactMock({
+		usePage: () => ({
+			props: {
+				selected_year: 2026,
+				available_years: [2025, 2026],
+				summary: {
+					year: 2026,
+					total_purchase_amount: 50000,
+					total_payout_amount: 45000,
+					total_net_amount: -5000,
+					total_return_rate: 90.0,
+				},
+				daily_balances: [
+					{
+						date: "2026-04-05",
+						purchase_amount: 3000,
+						payout_amount: 5000,
+						net_amount: 2000,
+						return_rate: 166.7,
+					},
+				],
+				next_cursor: "cursor-string",
+			},
+		}),
+		router: { get: routerGet, reload: routerReload },
+	}),
+);
 
 vi.mock("@/routes", () => ({
 	dashboard: Object.assign(() => "/dashboard", {

--- a/source/resources/js/pages/horses/show.int.test.tsx
+++ b/source/resources/js/pages/horses/show.int.test.tsx
@@ -1,44 +1,43 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { createInertiaReactMock } from "@/tests/mocks";
 import HorsesShow from "./show";
 
-vi.mock("@inertiajs/react", () => ({
-	Head: ({ title }: { title: string }) => <title>{title}</title>,
-	Link: ({ href, children }: { href: string; children: unknown }) => (
-		<a href={href}>{children as never}</a>
-	),
-	usePage: () => ({
-		props: {
-			horse: {
-				id: 100,
-				name: "ディープスター",
-				birth_year: 2022,
-				race_histories: [
-					{
-						race_id: 11,
-						race_uid: "abc001",
-						race_date: "2026-04-19",
-						venue_name: "東京",
-						race_number: 11,
-						race_name: "皐月賞",
-						finishing_order: 3,
-						jockey_name: "テスト騎手",
-						popularity: 5,
-					},
-				],
-				notes: [
-					{
-						id: 1,
-						content: "次走への備忘録",
-						race: null,
-						created_at: "2026-04-25T10:00:00Z",
-						updated_at: "2026-04-25T10:00:00Z",
-					},
-				],
+vi.mock("@inertiajs/react", () =>
+	createInertiaReactMock({
+		usePage: () => ({
+			props: {
+				horse: {
+					id: 100,
+					name: "ディープスター",
+					birth_year: 2022,
+					race_histories: [
+						{
+							race_id: 11,
+							race_uid: "abc001",
+							race_date: "2026-04-19",
+							venue_name: "東京",
+							race_number: 11,
+							race_name: "皐月賞",
+							finishing_order: 3,
+							jockey_name: "テスト騎手",
+							popularity: 5,
+						},
+					],
+					notes: [
+						{
+							id: 1,
+							content: "次走への備忘録",
+							race: null,
+							created_at: "2026-04-25T10:00:00Z",
+							updated_at: "2026-04-25T10:00:00Z",
+						},
+					],
+				},
 			},
-		},
+		}),
 	}),
-}));
+);
 
 describe("HorsesShow ページ", () => {
 	it("ハッピーパス: Inertia propsのデータが HorseDetail と HorseNotesListContainer に表示される", () => {

--- a/source/resources/js/pages/insights.int.test.tsx
+++ b/source/resources/js/pages/insights.int.test.tsx
@@ -1,54 +1,51 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createInertiaReactMock } from "@/tests/mocks";
 import Insights from "./insights";
 
-const routerGet = vi.fn();
+const { routerGet } = vi.hoisted(() => ({ routerGet: vi.fn() }));
 
-vi.mock("@inertiajs/react", () => ({
-	Head: ({ title }: { title: string }) => <title>{title}</title>,
-	usePage: () => ({
-		props: {
-			period: "1m",
-			summary: {
-				total_tickets: 10,
-				total_purchase_amount: 10000,
-				total_payout_amount: 8000,
-				return_rate: 80.0,
-				hit_rate: 20.0,
-			},
-			patternBreakdown: [
-				{ pattern: "hit", count: 2, ratio: 20.0 },
-				{ pattern: "axis_only", count: 1, ratio: 10.0 },
-				{ pattern: "others_only", count: 4, ratio: 40.0 },
-				{ pattern: "miss", count: 3, ratio: 30.0 },
-			],
-			popularityPatternMatrix: [],
-			popularityReturns: [],
-			monthlyTrends: [],
-			recentSamples: [
-				{
-					ticket_id: 1,
-					race_uid: "uid-1",
-					race_date: "2026-04-28",
-					venue_name: "東京",
-					race_number: 11,
-					axis_horse_numbers: [3],
-					axis_best_finishing_order: 1,
-					others_best_finishing_order: 2,
-					pattern: "hit",
-					purchase_amount: 1000,
-					payout_amount: 4200,
+vi.mock("@inertiajs/react", () =>
+	createInertiaReactMock({
+		usePage: () => ({
+			props: {
+				period: "1m",
+				summary: {
+					total_tickets: 10,
+					total_purchase_amount: 10000,
+					total_payout_amount: 8000,
+					return_rate: 80.0,
+					hit_rate: 20.0,
 				},
-			],
-		},
+				patternBreakdown: [
+					{ pattern: "hit", count: 2, ratio: 20.0 },
+					{ pattern: "axis_only", count: 1, ratio: 10.0 },
+					{ pattern: "others_only", count: 4, ratio: 40.0 },
+					{ pattern: "miss", count: 3, ratio: 30.0 },
+				],
+				popularityPatternMatrix: [],
+				popularityReturns: [],
+				monthlyTrends: [],
+				recentSamples: [
+					{
+						ticket_id: 1,
+						race_uid: "uid-1",
+						race_date: "2026-04-28",
+						venue_name: "東京",
+						race_number: 11,
+						axis_horse_numbers: [3],
+						axis_best_finishing_order: 1,
+						others_best_finishing_order: 2,
+						pattern: "hit",
+						purchase_amount: 1000,
+						payout_amount: 4200,
+					},
+				],
+			},
+		}),
+		router: { get: routerGet },
 	}),
-	router: {
-		get: (...args: unknown[]) => routerGet(...args),
-	},
-	Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
-		<a href={href}>{children}</a>
-	),
-}));
+);
 
 vi.mock("@/routes", () => ({
 	insights: Object.assign(() => "/insights", {

--- a/source/resources/js/pages/races/index.int.test.tsx
+++ b/source/resources/js/pages/races/index.int.test.tsx
@@ -1,33 +1,30 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createInertiaReactMock } from "@/tests/mocks";
 import RacesIndex from "./index";
 
-vi.mock("@inertiajs/react", () => ({
-	Head: ({ title }: { title: string }) => <title>{title}</title>,
-	usePage: () => ({
-		props: {
-			races: [
-				{
-					uid: "abc123",
+vi.mock("@inertiajs/react", () =>
+	createInertiaReactMock({
+		usePage: () => ({
+			props: {
+				races: [
+					{
+						uid: "abc123",
+						race_date: "2026-04-05",
+						venue_name: "東京",
+						race_number: 1,
+					},
+				],
+				venues: [{ id: 1, name: "東京" }],
+				filters: {
 					race_date: "2026-04-05",
-					venue_name: "東京",
-					race_number: 1,
+					venue_id: null,
 				},
-			],
-			venues: [{ id: 1, name: "東京" }],
-			filters: {
-				race_date: "2026-04-05",
-				venue_id: null,
 			},
-		},
+		}),
+		router: { get: vi.fn() },
 	}),
-	router: {
-		get: vi.fn(),
-	},
-	Link: ({ href, children }: { href: string; children: unknown }) => (
-		<a href={href}>{children as never}</a>
-	),
-}));
+);
 
 vi.mock("@/routes/races", () => ({
 	create: { url: () => "/races/new" },

--- a/source/resources/js/pages/races/result/create.int.test.tsx
+++ b/source/resources/js/pages/races/result/create.int.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createInertiaReactMock } from "@/tests/mocks";
 import RaceResultCreate from "./create";
 
 vi.mock("@inertiajs/react", async () => {
@@ -7,9 +8,8 @@ vi.mock("@inertiajs/react", async () => {
 		await vi.importActual<typeof import("@inertiajs/react")>(
 			"@inertiajs/react",
 		);
-	return {
-		...actual,
-		Head: ({ title }: { title: string }) => <title>{title}</title>,
+	return createInertiaReactMock({
+		actual,
 		usePage: () => ({
 			props: {
 				race: {
@@ -20,7 +20,7 @@ vi.mock("@inertiajs/react", async () => {
 				},
 			},
 		}),
-	};
+	});
 });
 
 describe("RaceResultCreate ページ", () => {

--- a/source/resources/js/pages/races/result/edit.int.test.tsx
+++ b/source/resources/js/pages/races/result/edit.int.test.tsx
@@ -1,53 +1,52 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { createInertiaReactMock } from "@/tests/mocks";
 import RaceResultEdit from "./edit";
 
-vi.mock("@inertiajs/react", () => ({
-	Head: ({ title }: { title: string }) => <title>{title}</title>,
-	Link: ({ href, children }: { href: string; children: unknown }) => (
-		<a href={href}>{children as never}</a>
-	),
-	usePage: () => ({
-		props: {
-			race: {
-				id: 200,
-				uid: "abc123",
-				venue_name: "東京",
-				race_date: "2026-04-05",
-				race_number: 3,
-				race_name: null,
-				payouts: [],
-				finishing_horses: [
-					{
-						finishing_order: 1,
-						frame_number: 1,
-						horse_number: 1,
-						horse_id: 100,
-						horse_name: "テストホース",
-						jockey_name: "テスト騎手",
-						race_time: "1:34.5",
-						note: {
-							id: 5,
-							content: "前走は出遅れ気味",
-							source: "race",
+vi.mock("@inertiajs/react", () =>
+	createInertiaReactMock({
+		usePage: () => ({
+			props: {
+				race: {
+					id: 200,
+					uid: "abc123",
+					venue_name: "東京",
+					race_date: "2026-04-05",
+					race_number: 3,
+					race_name: null,
+					payouts: [],
+					finishing_horses: [
+						{
+							finishing_order: 1,
+							frame_number: 1,
+							horse_number: 1,
+							horse_id: 100,
+							horse_name: "テストホース",
+							jockey_name: "テスト騎手",
+							race_time: "1:34.5",
+							note: {
+								id: 5,
+								content: "前走は出遅れ気味",
+								source: "race",
+							},
 						},
+					],
+				},
+				tickets: [
+					{
+						id: 1,
+						ticket_type_label: "馬連",
+						buy_type_name: "box",
+						buy_type_label: "ボックス",
+						selections: { horses: [1, 3, 5] },
+						purchase_amount: 3000,
+						payout_amount: 700,
 					},
 				],
 			},
-			tickets: [
-				{
-					id: 1,
-					ticket_type_label: "馬連",
-					buy_type_name: "box",
-					buy_type_label: "ボックス",
-					selections: { horses: [1, 3, 5] },
-					purchase_amount: 3000,
-					payout_amount: 700,
-				},
-			],
-		},
+		}),
 	}),
-}));
+);
 
 describe("RaceResultEdit ページ", () => {
 	it("ハッピーパス: Inertia propsのデータが RaceResultDetail に表示され、メモセルが描画される", () => {

--- a/source/resources/js/pages/races/show.int.test.tsx
+++ b/source/resources/js/pages/races/show.int.test.tsx
@@ -1,41 +1,40 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createInertiaReactMock } from "@/tests/mocks";
 import RacesShow from "./show";
 
-vi.mock("@inertiajs/react", () => ({
-	Head: ({ title }: { title: string }) => <title>{title}</title>,
-	Link: ({ href, children }: { href: string; children: unknown }) => (
-		<a href={href}>{children as never}</a>
-	),
-	usePage: () => ({
-		props: {
-			race: {
-				id: 200,
-				uid: "abc123",
-				race_date: "2026-04-05",
-				venue_name: "東京",
-				race_number: 3,
-				race_name: "皐月賞",
-				entries: [
-					{
-						id: 1,
-						frame_number: 1,
-						horse_number: 1,
-						horse_id: 100,
-						horse_name: "テストホース",
-						jockey_name: "テスト騎手",
-						weight: 480,
-						note: null,
-					},
-				],
-				mark_columns: [
-					{ id: 100, type: "own", label: null, display_order: 0 },
-				],
-				marks: [],
+vi.mock("@inertiajs/react", () =>
+	createInertiaReactMock({
+		usePage: () => ({
+			props: {
+				race: {
+					id: 200,
+					uid: "abc123",
+					race_date: "2026-04-05",
+					venue_name: "東京",
+					race_number: 3,
+					race_name: "皐月賞",
+					entries: [
+						{
+							id: 1,
+							frame_number: 1,
+							horse_number: 1,
+							horse_id: 100,
+							horse_name: "テストホース",
+							jockey_name: "テスト騎手",
+							weight: 480,
+							note: null,
+						},
+					],
+					mark_columns: [
+						{ id: 100, type: "own", label: null, display_order: 0 },
+					],
+					marks: [],
+				},
 			},
-		},
+		}),
 	}),
-}));
+);
 
 describe("RacesShow ページ", () => {
 	it("ハッピーパス: Inertia propsのデータがRaceDetailに表示される", () => {

--- a/source/resources/js/pages/tickets/index.int.test.tsx
+++ b/source/resources/js/pages/tickets/index.int.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@inertiajs/react", () =>
 	}),
 );
 
+// vi.mock factory が createInertiaReactMock を参照するため、`@inertiajs/react` の import は vi.mock の後に置く（前に置くと __vi_import 未初期化エラー）
 import { router } from "@inertiajs/react";
 import TicketsIndex from "./index";
 

--- a/source/resources/js/pages/tickets/index.int.test.tsx
+++ b/source/resources/js/pages/tickets/index.int.test.tsx
@@ -1,40 +1,42 @@
-import { router } from "@inertiajs/react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import TicketsIndex from "./index";
+import { createInertiaReactMock } from "@/tests/mocks";
 
-vi.mock("@inertiajs/react", () => ({
-	Head: ({ title }: { title: string }) => <title>{title}</title>,
-	usePage: () => ({
-		props: {
-			purchases: [
-				{
-					id: 1,
-					race_uid: null,
-					has_race_result: false,
-					race_date: "2026-04-05",
-					venue_name: "東京",
-					race_number: 1,
-					ticket_type_label: "馬連",
-					buy_type_name: "nagashi",
-					selections: { axis: [1], others: [2, 4, 6] },
-					num_combinations: 3,
-					purchase_amount: 100,
-					payout_amount: null,
-				},
-			],
-			nextCursor: null,
-		},
-	}),
-	router: {
-		reload: vi.fn(),
-		delete: vi.fn(),
-	},
-	Link: ({ href, children }: { href: string; children: unknown }) => (
-		<a href={href}>{children as never}</a>
-	),
+const { routerReload, routerDelete } = vi.hoisted(() => ({
+	routerReload: vi.fn(),
+	routerDelete: vi.fn(),
 }));
+
+vi.mock("@inertiajs/react", () =>
+	createInertiaReactMock({
+		usePage: () => ({
+			props: {
+				purchases: [
+					{
+						id: 1,
+						race_uid: null,
+						has_race_result: false,
+						race_date: "2026-04-05",
+						venue_name: "東京",
+						race_number: 1,
+						ticket_type_label: "馬連",
+						buy_type_name: "nagashi",
+						selections: { axis: [1], others: [2, 4, 6] },
+						num_combinations: 3,
+						purchase_amount: 100,
+						payout_amount: null,
+					},
+				],
+				nextCursor: null,
+			},
+		}),
+		router: { reload: routerReload, delete: routerDelete },
+	}),
+);
+
+import { router } from "@inertiajs/react";
+import TicketsIndex from "./index";
 
 vi.mock("@/routes/tickets", () => ({
 	newMethod: {

--- a/source/resources/js/pages/tickets/new.int.test.tsx
+++ b/source/resources/js/pages/tickets/new.int.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createInertiaReactMock } from "@/tests/mocks";
 import TicketsNew from "./new";
 
 vi.mock("@inertiajs/react", async () => {
@@ -7,9 +8,8 @@ vi.mock("@inertiajs/react", async () => {
 		await vi.importActual<typeof import("@inertiajs/react")>(
 			"@inertiajs/react",
 		);
-	return {
-		...actual,
-		Head: ({ title }: { title: string }) => <title>{title}</title>,
+	return createInertiaReactMock({
+		actual,
 		usePage: () => ({
 			props: {
 				lastVenue: "東京",
@@ -17,7 +17,7 @@ vi.mock("@inertiajs/react", async () => {
 				lastRaceNumber: 1,
 			},
 		}),
-	};
+	});
 });
 
 describe("TicketsNew ページ", () => {

--- a/source/resources/js/tests/mocks.tsx
+++ b/source/resources/js/tests/mocks.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+import { vi } from "vitest";
+
+type RouterMethod =
+	| "get"
+	| "post"
+	| "put"
+	| "patch"
+	| "delete"
+	| "reload"
+	| "visit";
+
+type RouterFns = Partial<Record<RouterMethod, ReturnType<typeof vi.fn>>>;
+
+type UsePageFn = () => { props: Record<string, unknown> };
+
+const defaultUsePage: UsePageFn = () => ({ props: {} });
+
+const MockHead = ({ title }: { title: string }) => <title>{title}</title>;
+
+const MockLink = ({
+	href,
+	children,
+}: {
+	href: string;
+	children: ReactNode;
+}) => <a href={href}>{children}</a>;
+
+export function createInertiaReactMock(
+	opts: {
+		usePage?: UsePageFn;
+		router?: RouterFns;
+		actual?: object;
+	} = {},
+) {
+	return {
+		...(opts.actual ?? {}),
+		Head: MockHead,
+		Link: MockLink,
+		usePage: opts.usePage ?? defaultUsePage,
+		router: opts.router ?? {},
+	};
+}
+
+export function createInertiaCoreMock<T extends object>(actual: T) {
+	return {
+		...actual,
+		router: {
+			post: vi.fn(),
+			put: vi.fn(),
+			patch: vi.fn(),
+			delete: vi.fn(),
+			visit: vi.fn(),
+			reload: vi.fn(),
+		},
+	};
+}

--- a/source/resources/js/tests/mocks.tsx
+++ b/source/resources/js/tests/mocks.tsx
@@ -1,16 +1,7 @@
 import type { ReactNode } from "react";
 import { vi } from "vitest";
 
-type RouterMethod =
-	| "get"
-	| "post"
-	| "put"
-	| "patch"
-	| "delete"
-	| "reload"
-	| "visit";
-
-type RouterFns = Partial<Record<RouterMethod, ReturnType<typeof vi.fn>>>;
+type RouterFns = Record<string, ReturnType<typeof vi.fn>>;
 
 type UsePageFn = () => { props: Record<string, unknown> };
 
@@ -38,14 +29,19 @@ export function createInertiaReactMock(
 		Head: MockHead,
 		Link: MockLink,
 		usePage: opts.usePage ?? defaultUsePage,
-		router: opts.router ?? {},
+		...(opts.router ? { router: opts.router } : {}),
 	};
 }
 
-export function createInertiaCoreMock<T extends object>(actual: T) {
+export function createInertiaCoreMock<T extends object>(
+	opts: {
+		actual?: T;
+		router?: RouterFns;
+	} = {},
+) {
 	return {
-		...actual,
-		router: {
+		...(opts.actual ?? {}),
+		router: opts.router ?? {
 			post: vi.fn(),
 			put: vi.fn(),
 			patch: vi.fn(),


### PR DESCRIPTION
## やったこと

- `resources/js/tests/mocks.tsx` に `createInertiaReactMock` / `createInertiaCoreMock` の 2 ファクトリ関数を新規作成
- ページ系 9 ファイル（`@inertiajs/react` モック）をヘルパー利用に置き換え
- コンテナ系 6 ファイル（`@inertiajs/core` router モック）をヘルパー利用に置き換え
- `usePage` の戻り値はドメイン依存のため引き続き各テストでインライン記述
- `useForm` 等の実際の Inertia 実装が必要なファイルは `actual` spread をオプション対応で対処
- モジュールレベル `vi.fn()` を使うテストは Vitest のホイスティング順序問題を `vi.hoisted` で解消
- issue #246 本文を実態（20 ファイル / 2 パターン / `tests/mocks.tsx`）に合わせて更新

## 結果

変更前と比べてボイラープレートが削減され（15 ファイル、正味 -3 行/ファイル）、今後は `createInertiaCoreMock` / `createInertiaReactMock` を呼ぶだけで同じモック構造が再現できる。

## 動作確認済み

- [ ] vitest でページ系 8 / 9、コンテナ系 4 / 6 が pass（残りの失敗は Wayfinder 生成ファイル不整合による既存問題で私の変更とは無関係であることを確認済み）