### PR TITLE
[patch] レース結果・出走馬登録の馬名から JRA 注記 prefix を除去

### DIFF
--- a/source/app/Services/HorseNameNormalizer.php
+++ b/source/app/Services/HorseNameNormalizer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * 馬名文字列を正規化するユーティリティ。
+ *
+ * JRA 公式サイトからコピペしたテキストには、外国産馬や地方競馬所属馬を示す注記が
+ * 馬名と連結した形（例: `マルガイユウファラオ`）で含まれることがある。
+ * この注記を除去し、`horses.name` には馬名本体だけが流れるようにする。
+ */
+class HorseNameNormalizer
+{
+    /**
+     * JRA 着順テキスト・出馬表テキストに現れる馬名の注記 prefix。
+     *
+     * 現在の JRA で出馬表にテキスト化されることが確認できているもののみを対象とする。
+     * 廃止された prefix（マルフ・マルイチ など）や裏付けが取れていないものは含めない。
+     *
+     * @var array<int, string>
+     */
+    private const JRA_ANNOTATION_PREFIXES = [
+        'マルガイ', // ○外: 外国産馬
+        'カクガイ', // □外: 外国馬（海外調教馬）
+        'マルチ',   // ○地: 地方競馬所属馬
+    ];
+
+    /**
+     * 馬名から JRA 注記 prefix を除去する。
+     *
+     * 先頭が登録済み prefix のいずれかと一致する場合に限り、最長一致した prefix を
+     * 1 回だけ取り除いて返す。除去後に空文字になる場合（馬名が prefix のみで構成）は
+     * 元の文字列をそのまま返し、誤除去を避ける。
+     */
+    public static function stripJraAnnotationPrefix(string $name): string
+    {
+        $matchedPrefix = null;
+        foreach (self::JRA_ANNOTATION_PREFIXES as $prefix) {
+            if (! str_starts_with($name, $prefix)) {
+                continue;
+            }
+            if ($matchedPrefix === null || mb_strlen($prefix) > mb_strlen($matchedPrefix)) {
+                $matchedPrefix = $prefix;
+            }
+        }
+
+        if ($matchedPrefix === null) {
+            return $name;
+        }
+
+        $stripped = mb_substr($name, mb_strlen($matchedPrefix));
+        if ($stripped === '') {
+            return $name;
+        }
+
+        return $stripped;
+    }
+}

--- a/source/app/Services/RaceEntryParser.php
+++ b/source/app/Services/RaceEntryParser.php
@@ -127,7 +127,7 @@ class RaceEntryParser
                 if ($line === 'ブリンカー着用') {
                     continue;
                 }
-                $horseName = $line;
+                $horseName = HorseNameNormalizer::stripJraAnnotationPrefix($line);
 
                 continue;
             }

--- a/source/app/Services/RaceResultHorseParser.php
+++ b/source/app/Services/RaceResultHorseParser.php
@@ -159,7 +159,7 @@ class RaceResultHorseParser
             );
         }
 
-        $horseName = trim($cols1[3]);
+        $horseName = HorseNameNormalizer::stripJraAnnotationPrefix(trim($cols1[3]));
         if ($horseName === '') {
             throw new \InvalidArgumentException(sprintf('%d頭目: 馬名が空です。', $horseIndex));
         }
@@ -209,7 +209,7 @@ class RaceResultHorseParser
             );
         }
 
-        $horseName = trim($cols1[3]);
+        $horseName = HorseNameNormalizer::stripJraAnnotationPrefix(trim($cols1[3]));
         if ($horseName === '') {
             throw new \InvalidArgumentException(sprintf('%d頭目: 馬名が空です。', $horseIndex));
         }
@@ -266,7 +266,7 @@ class RaceResultHorseParser
             );
         }
 
-        $horseName = trim($block[1]);
+        $horseName = HorseNameNormalizer::stripJraAnnotationPrefix(trim($block[1]));
         if ($horseName === '') {
             throw new \InvalidArgumentException(sprintf('%d頭目: 馬名が空です。', $horseIndex));
         }

--- a/source/tests/Unit/HorseNameNormalizerTest.php
+++ b/source/tests/Unit/HorseNameNormalizerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Services\HorseNameNormalizer;
+
+// ===== HorseNameNormalizer::stripJraAnnotationPrefix() =====
+
+test('JRA 注記 prefix が馬名先頭に付いている場合は除去される', function (string $input, string $expected) {
+    expect(HorseNameNormalizer::stripJraAnnotationPrefix($input))->toBe($expected);
+})->with([
+    'マルガイ（外国産馬）' => ['マルガイユウファラオ', 'ユウファラオ'],
+    'カクガイ（外国馬）' => ['カクガイテストホース', 'テストホース'],
+    'マルチ（地方競馬所属馬）' => ['マルチオーシャンステラ', 'オーシャンステラ'],
+]);
+
+test('注記 prefix を含まない馬名は変更されない', function () {
+    expect(HorseNameNormalizer::stripJraAnnotationPrefix('エビスディアーナ'))
+        ->toBe('エビスディアーナ');
+});
+
+test('空文字は空文字のまま返される', function () {
+    expect(HorseNameNormalizer::stripJraAnnotationPrefix(''))->toBe('');
+});
+
+test('prefix 文字列と完全一致する場合は除去せずに元の文字列を返す', function (string $input) {
+    expect(HorseNameNormalizer::stripJraAnnotationPrefix($input))->toBe($input);
+})->with([
+    'マルガイのみ' => ['マルガイ'],
+    'カクガイのみ' => ['カクガイ'],
+    'マルチのみ' => ['マルチ'],
+]);

--- a/source/tests/Unit/RaceEntryParserTest.php
+++ b/source/tests/Unit/RaceEntryParserTest.php
@@ -205,3 +205,38 @@ test('複数頭分のエントリが正しくパースされる', function () us
     expect($result[1]['horse_weight'])->toBe(510);
     expect($result[1]['birth_year'])->toBe(2021);
 });
+
+test('馬名行に JRA 注記 prefix が含まれる場合は除去される', function () {
+    // Arrange
+    $entryTextWithPrefix = implode("\n", [
+        '枠1白	1	',
+        'マルガイユウファラオ	',
+        '127.8',
+        '(11番人気)',
+        '426kg(-2)',
+        '加藤 晃央',
+        '',
+        '恵比寿牧場',
+        '',
+        '加藤 征弘(美浦)',
+        '',
+        '父：マジェスティックウォリアー',
+        '母：エビスオール',
+        '(母の父：Chief Seattle)',
+        '勝負服の画像',
+        '',
+        '牝3/黒鹿',
+        '',
+        '55.0kg',
+        '',
+        'M.ディー',
+    ]);
+    $parser = new RaceEntryParser;
+    $raceDate = Carbon::create(2026, 4, 18);
+
+    // Act
+    $result = $parser->parse($entryTextWithPrefix, $raceDate);
+
+    // Assert
+    expect($result[0]['horse_name'])->toBe('ユウファラオ');
+});

--- a/source/tests/Unit/RaceResultHorseParserTest.php
+++ b/source/tests/Unit/RaceResultHorseParserTest.php
@@ -45,3 +45,19 @@ test('馬体重カラムが不正な形式のとき例外が投げられる', fu
     // Act & Assert
     expect(fn () => $parser->parse($text))->toThrow(InvalidArgumentException::class);
 });
+
+// ===== RaceResultHorseParser::parse() 馬名 JRA 注記 prefix の除去 =====
+
+test('馬名カラムに JRA 注記 prefix が含まれる場合は除去される', function () {
+    // Arrange
+    $parser = new RaceResultHorseParser;
+    $text = "1\t枠1白\t1\tマルガイテスト馬\t牡4\t57.0\tテスト騎手\t1:35.0\t\n"
+        ."1 1 1 1\n"
+        ."35.5\t508\tテスト調教師\t1";
+
+    // Act
+    $result = $parser->parse($text);
+
+    // Assert
+    expect($result[0]['horse_name'])->toBe('テスト馬');
+});


### PR DESCRIPTION
## やったこと

- JRA 公式サイトからコピペしたテキストをパースする際、外国産馬などを示す注記 prefix（マルガイ・カクガイ・マルチ）が馬名と連結したまま `horses.name` に保存されてしまう問題を修正
- `HorseNameNormalizer` を新設し、除去対象 prefix を定数 1 か所で管理（追加・削除が容易）
- `RaceResultHorseParser`（着順テキスト）の馬名抽出 3 箇所と `RaceEntryParser`（出走馬登録テキスト）の馬名抽出 1 箇所にて、パース境界で prefix を除去するよう対応

## 結果

UI 上の変化なし（パーサ内部の正規化処理の追加）。
`マルガイユウファラオ` のような注記付き入力を行うと、`horses.name` に `ユウファラオ` が保存されるようになる。

## 動作確認済み

- [x] `HorseNameNormalizerTest` — 各 prefix の除去・prefix なし・空文字・完全一致セーフガードを検証
- [x] `RaceResultHorseParserTest` — 馬名カラムに `マルガイ` 付き入力を与え `horse_name` が除去済みになることを確認
- [x] `RaceEntryParserTest` — 馬名行に `マルガイ` 付き入力を与え `horse_name` が除去済みになることを確認