### PR TITLE
[patch] NanoId 衝突時のリトライ機構を追加

### DIFF
--- a/source/app/Concerns/HasNanoIdUid.php
+++ b/source/app/Concerns/HasNanoIdUid.php
@@ -44,7 +44,7 @@ trait HasNanoIdUid
             try {
                 return parent::save($options);
             } catch (QueryException $e) {
-                if (! static::isUidUniqueViolation($e) || $attempts >= static::$uidMaxRetries) {
+                if (! $this->isUidUniqueViolation($e) || $attempts >= static::$uidMaxRetries) {
                     throw $e;
                 }
                 $attempts++;
@@ -53,19 +53,26 @@ trait HasNanoIdUid
         }
     }
 
-    protected static function isUidUniqueViolation(QueryException $e): bool
+    /**
+     * テーブル名で前置することで、同テーブル内に `*_{$uidColumn}` を末尾に持つ
+     * 別カラム (例: external_uid) があっても誤マッチしない。
+     * UNIQUE インデックス名を Laravel デフォルト命名規則 (`{table}_{col}_unique`)
+     * から変更している場合は別途調整が必要。
+     */
+    protected function isUidUniqueViolation(QueryException $e): bool
     {
         if ((string) $e->getCode() !== '23000') {
             return false;
         }
         $col = static::$uidColumn;
+        $table = $this->getTable();
         $msg = $e->getMessage();
 
-        // MySQL: "for key 'horses.horses_uid_unique'"
-        // SQLite: "UNIQUE constraint failed: horses.uid"
-        return str_contains($msg, ".{$col}")
-            || str_contains($msg, "_{$col}_unique")
-            || str_contains($msg, "'{$col}'");
+        // SQLite: "UNIQUE constraint failed: {table}.{col}"
+        // MySQL (8.0+): "for key '{table}.{table}_{col}_unique'"
+        // MySQL (旧):    "for key '{table}_{col}_unique'"
+        return str_contains($msg, "{$table}.{$col}")
+            || str_contains($msg, "{$table}_{$col}_unique");
     }
 
     protected static function generateUid(): string

--- a/source/app/Concerns/HasNanoIdUid.php
+++ b/source/app/Concerns/HasNanoIdUid.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Concerns;
+
+use App\Support\NanoId;
+use Illuminate\Database\QueryException;
+
+/**
+ * NanoId 由来の uid カラムを採番する Eloquent モデル向け Trait。
+ *
+ * - creating フックで uid 未設定なら採番する
+ * - save() 時に uid カラムの UNIQUE 衝突 (SQLSTATE 23000) が起きたら
+ *   再採番して最大 self::$uidMaxRetries 回までリトライする
+ * - 上限超過時は最後の QueryException をそのまま throw する
+ * - テスト時は fakeUidQueue() で採番値を差し替えられる
+ */
+trait HasNanoIdUid
+{
+    protected static string $uidColumn = 'uid';
+
+    protected static int $uidMaxRetries = 3;
+
+    /** @var array<int, string> */
+    protected static array $fakeUidQueue = [];
+
+    public static function bootHasNanoIdUid(): void
+    {
+        static::creating(function (self $model): void {
+            $column = static::$uidColumn;
+            if (empty($model->{$column})) {
+                $model->{$column} = static::generateUid();
+            }
+        });
+    }
+
+    public function save(array $options = []): bool
+    {
+        if ($this->exists) {
+            return parent::save($options);
+        }
+
+        $attempts = 0;
+        while (true) {
+            try {
+                return parent::save($options);
+            } catch (QueryException $e) {
+                if (! static::isUidUniqueViolation($e) || $attempts >= static::$uidMaxRetries) {
+                    throw $e;
+                }
+                $attempts++;
+                $this->{static::$uidColumn} = static::generateUid();
+            }
+        }
+    }
+
+    protected static function isUidUniqueViolation(QueryException $e): bool
+    {
+        if ((string) $e->getCode() !== '23000') {
+            return false;
+        }
+        $col = static::$uidColumn;
+        $msg = $e->getMessage();
+
+        // MySQL: "for key 'horses.horses_uid_unique'"
+        // SQLite: "UNIQUE constraint failed: horses.uid"
+        return str_contains($msg, ".{$col}")
+            || str_contains($msg, "_{$col}_unique")
+            || str_contains($msg, "'{$col}'");
+    }
+
+    protected static function generateUid(): string
+    {
+        if (! empty(static::$fakeUidQueue)) {
+            return array_shift(static::$fakeUidQueue);
+        }
+
+        return NanoId::generate();
+    }
+
+    /**
+     * @param  array<int, string>  $ids
+     */
+    public static function fakeUidQueue(array $ids): void
+    {
+        static::$fakeUidQueue = $ids;
+    }
+
+    public static function clearUidGeneratorState(): void
+    {
+        static::$fakeUidQueue = [];
+    }
+}

--- a/source/app/Models/Horse.php
+++ b/source/app/Models/Horse.php
@@ -2,26 +2,19 @@
 
 namespace App\Models;
 
-use App\Support\NanoId;
+use App\Concerns\HasNanoIdUid;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Horse extends Model
 {
+    use HasNanoIdUid;
+
     protected $fillable = [
         'uid',
         'name',
         'birth_year',
     ];
-
-    protected static function booted(): void
-    {
-        static::creating(function (Horse $horse): void {
-            if (empty($horse->uid)) {
-                $horse->uid = NanoId::generate();
-            }
-        });
-    }
 
     /** @return HasMany<RaceEntry, $this> */
     public function raceEntries(): HasMany

--- a/source/app/Models/Race.php
+++ b/source/app/Models/Race.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Support\NanoId;
+use App\Concerns\HasNanoIdUid;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Race extends Model
 {
     use HasFactory;
+    use HasNanoIdUid;
 
     protected $fillable = [
         'uid',
@@ -19,15 +20,6 @@ class Race extends Model
         'race_number',
         'race_name',
     ];
-
-    protected static function booted(): void
-    {
-        static::creating(function (Race $race): void {
-            if (empty($race->uid)) {
-                $race->uid = NanoId::generate();
-            }
-        });
-    }
 
     /** @return BelongsTo<Venue, $this> */
     public function venue(): BelongsTo

--- a/source/app/Models/RaceEntry.php
+++ b/source/app/Models/RaceEntry.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
-use App\Support\NanoId;
+use App\Concerns\HasNanoIdUid;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class RaceEntry extends Model
 {
+    use HasNanoIdUid;
+
     protected $fillable = [
         'uid',
         'race_id',
@@ -18,15 +20,6 @@ class RaceEntry extends Model
         'weight',
         'horse_weight',
     ];
-
-    protected static function booted(): void
-    {
-        static::creating(function (RaceEntry $entry): void {
-            if (empty($entry->uid)) {
-                $entry->uid = NanoId::generate();
-            }
-        });
-    }
 
     /** @return BelongsTo<Race, $this> */
     public function race(): BelongsTo

--- a/source/tests/Feature/Concerns/HasNanoIdUidTest.php
+++ b/source/tests/Feature/Concerns/HasNanoIdUidTest.php
@@ -1,0 +1,203 @@
+<?php
+
+use App\Models\Horse;
+use App\Models\Jockey;
+use App\Models\Race;
+use App\Models\RaceEntry;
+use App\Support\NanoId;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+
+afterEach(function () {
+    Horse::clearUidGeneratorState();
+    RaceEntry::clearUidGeneratorState();
+    Race::clearUidGeneratorState();
+});
+
+test('uid 未指定で create すると NanoId が自動採番される', function () {
+    $horse = Horse::create(['name' => 'テスト馬', 'birth_year' => 2020]);
+
+    expect($horse->uid)->toBeString();
+    expect(strlen($horse->uid))->toBe(21);
+});
+
+test('uid を明示指定して create するとその値が保持される', function () {
+    $horse = Horse::create([
+        'uid' => 'explicit-uid-12345',
+        'name' => 'テスト馬',
+        'birth_year' => 2020,
+    ]);
+
+    expect($horse->uid)->toBe('explicit-uid-12345');
+});
+
+test('uid が UNIQUE 衝突したとき再採番してリトライ成功する', function () {
+    $existing = Horse::create([
+        'uid' => 'collision-uid',
+        'name' => '先発',
+        'birth_year' => 2020,
+    ]);
+
+    Horse::fakeUidQueue([$existing->uid, 'fresh-unique-uid-001']);
+
+    $horse = Horse::create(['name' => '後発', 'birth_year' => 2021]);
+
+    expect($horse->uid)->toBe('fresh-unique-uid-001');
+    expect(Horse::count())->toBe(2);
+});
+
+test('uid のリトライは最大 3 回まで実行され超過時は QueryException が throw される', function () {
+    Horse::create([
+        'uid' => 'always-collide',
+        'name' => '先発',
+        'birth_year' => 2020,
+    ]);
+
+    // 初回採番 + 3 リトライの計 4 回すべて衝突
+    Horse::fakeUidQueue(array_fill(0, 4, 'always-collide'));
+
+    expect(fn () => Horse::create(['name' => '後発', 'birth_year' => 2021]))
+        ->toThrow(QueryException::class);
+
+    // 後発はコミットされていない
+    expect(Horse::count())->toBe(1);
+});
+
+test('他カラムの UNIQUE 違反 (race_id, horse_number) はリトライされず即 throw される', function () {
+    $horse1 = Horse::create(['name' => '馬1', 'birth_year' => 2020]);
+    $horse2 = Horse::create(['name' => '馬2', 'birth_year' => 2020]);
+    $jockey = Jockey::create(['name' => '騎手1']);
+    $race = Race::factory()->create();
+
+    RaceEntry::create([
+        'race_id' => $race->id,
+        'horse_id' => $horse1->id,
+        'jockey_id' => $jockey->id,
+        'frame_number' => 1,
+        'horse_number' => 1,
+        'weight' => 55.0,
+    ]);
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    expect(fn () => RaceEntry::create([
+        'race_id' => $race->id,
+        'horse_id' => $horse2->id,
+        'jockey_id' => $jockey->id,
+        'frame_number' => 2,
+        'horse_number' => 1, // (race_id, horse_number) で衝突
+        'weight' => 55.0,
+    ]))->toThrow(QueryException::class);
+
+    // race_entries への INSERT は 1 回のみ。リトライされていないことを保証する。
+    $insertCount = collect(DB::getQueryLog())
+        ->filter(fn ($q) => str_contains($q['query'], 'race_entries')
+            && stripos($q['query'], 'insert') === 0)
+        ->count();
+    expect($insertCount)->toBe(1);
+
+    DB::disableQueryLog();
+});
+
+test('Race モデルでも UNIQUE 衝突時にリトライされる', function () {
+    $existing = Race::factory()->create(['uid' => 'race-collision']);
+
+    Race::fakeUidQueue(['race-collision', 'race-fresh-uid']);
+
+    $race = Race::factory()->create();
+
+    expect($race->uid)->toBe('race-fresh-uid');
+});
+
+test('RaceEntry モデルでも UNIQUE 衝突時にリトライされる', function () {
+    $horse1 = Horse::create(['name' => '馬1', 'birth_year' => 2020]);
+    $horse2 = Horse::create(['name' => '馬2', 'birth_year' => 2020]);
+    $jockey = Jockey::create(['name' => '騎手1']);
+    $race = Race::factory()->create();
+
+    $existing = RaceEntry::create([
+        'uid' => 'entry-collision',
+        'race_id' => $race->id,
+        'horse_id' => $horse1->id,
+        'jockey_id' => $jockey->id,
+        'frame_number' => 1,
+        'horse_number' => 1,
+        'weight' => 55.0,
+    ]);
+
+    RaceEntry::fakeUidQueue([$existing->uid, 'entry-fresh-uid']);
+
+    $entry = RaceEntry::create([
+        'race_id' => $race->id,
+        'horse_id' => $horse2->id,
+        'jockey_id' => $jockey->id,
+        'frame_number' => 2,
+        'horse_number' => 2,
+        'weight' => 55.0,
+    ]);
+
+    expect($entry->uid)->toBe('entry-fresh-uid');
+});
+
+test('DB トランザクション内で uid 衝突→リトライしても正常に保存できる', function () {
+    Horse::create([
+        'uid' => 'trans-collision',
+        'name' => '先発',
+        'birth_year' => 2020,
+    ]);
+
+    Horse::fakeUidQueue(['trans-collision', 'trans-fresh-uid']);
+
+    $horse = DB::transaction(function () {
+        return Horse::create(['name' => '後発', 'birth_year' => 2021]);
+    });
+
+    expect($horse->uid)->toBe('trans-fresh-uid');
+    expect(Horse::count())->toBe(2);
+});
+
+test('既存レコードの update 時は uid を再採番しない', function () {
+    $horse = Horse::create([
+        'uid' => 'keep-this-uid',
+        'name' => '初期名',
+        'birth_year' => 2020,
+    ]);
+
+    Horse::fakeUidQueue(['should-not-be-used']);
+
+    $horse->name = '変更後の名前';
+    $horse->save();
+
+    expect($horse->fresh()->uid)->toBe('keep-this-uid');
+    expect($horse->fresh()->name)->toBe('変更後の名前');
+});
+
+test('fakeUidQueue はモデル間で独立している', function () {
+    Horse::fakeUidQueue(['horse-only-uid']);
+    Race::fakeUidQueue(['race-only-uid']);
+
+    $horse = Horse::create(['name' => 'テスト', 'birth_year' => 2020]);
+    $race = Race::factory()->create();
+
+    expect($horse->uid)->toBe('horse-only-uid');
+    expect($race->uid)->toBe('race-only-uid');
+});
+
+test('NanoId::generate がフォールバックとして呼ばれる (fakeUidQueue 空時)', function () {
+    Horse::fakeUidQueue([]);
+
+    $horse = Horse::create(['name' => 'テスト', 'birth_year' => 2020]);
+
+    // フォールバック後の NanoId 採番値が 21 文字英数字_-である
+    expect($horse->uid)->toMatch('/^[A-Za-z0-9_-]{21}$/');
+});
+
+test('NanoId クラスの生成値とトレイトの採番ロジックが整合する', function () {
+    // smoke: NanoId::generate() を直接呼んで形式を確認
+    $generated = NanoId::generate();
+    expect(strlen($generated))->toBe(21);
+
+    $horse = Horse::create(['name' => 'テスト', 'birth_year' => 2020]);
+    expect(strlen($horse->uid))->toBe(21);
+});

--- a/source/tests/Feature/Concerns/HasNanoIdUidTest.php
+++ b/source/tests/Feature/Concerns/HasNanoIdUidTest.php
@@ -78,8 +78,15 @@ test('他カラムの UNIQUE 違反 (race_id, horse_number) はリトライさ�
         'weight' => 55.0,
     ]);
 
-    DB::flushQueryLog();
-    DB::enableQueryLog();
+    // QueryException で失敗したクエリは DB::getQueryLog() に記録されない
+    // (Connection::run() が re-throw 時に logQuery() をスキップするため)。
+    // 試行ごとにカウントするには beforeExecuting コールバックを使う。
+    $insertAttempts = 0;
+    DB::beforeExecuting(function ($query) use (&$insertAttempts) {
+        if (stripos($query, 'insert') === 0 && str_contains($query, 'race_entries')) {
+            $insertAttempts++;
+        }
+    });
 
     expect(fn () => RaceEntry::create([
         'race_id' => $race->id,
@@ -91,13 +98,7 @@ test('他カラムの UNIQUE 違反 (race_id, horse_number) はリトライさ�
     ]))->toThrow(QueryException::class);
 
     // race_entries への INSERT は 1 回のみ。リトライされていないことを保証する。
-    $insertCount = collect(DB::getQueryLog())
-        ->filter(fn ($q) => str_contains($q['query'], 'race_entries')
-            && stripos($q['query'], 'insert') === 0)
-        ->count();
-    expect($insertCount)->toBe(1);
-
-    DB::disableQueryLog();
+    expect($insertAttempts)->toBe(1);
 });
 
 test('Race モデルでも UNIQUE 衝突時にリトライされる', function () {


### PR DESCRIPTION
## やったこと

- `app/Concerns/HasNanoIdUid` トレイトを新設し、`Horse` / `RaceEntry` / `Race` の重複していた uid 採番ロジックを集約
- `creating` フックで uid 未設定のモデルに NanoId を採番する共通実装
- `save()` をオーバーライドして UNIQUE 制約違反 (SQLSTATE 23000) を捕捉し、最大 3 回まで uid を再採番してリトライ
- メッセージ判定で複合 UNIQUE 制約 (例: `race_entries.(race_id, horse_number)`) と区別し、uid 以外の違反は誤リトライしない
- テスト用 `fakeUidQueue()` ヘルパで衝突を決定的に再現できる仕組みを追加
- 3 モデルから重複していた `booted()` を削除

## 結果

テストコードで動作を担保しているためスクリーンショットなし。

## 動作確認済み

- [ ] 特になし（テストコードにて確認）