### PR TITLE
[patch] .claude/settings.json の無効な Write パーミッションルールを削除

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,16 +31,8 @@
       "Bash(pnpm tc*)",
       "Bash(pnpm run tc*)",
       "Bash(vendor/bin/sail bin pint*)",
-      "Write(.claude/skills/**)",
-      "Write(**/*.tsx)",
-      "Write(**/*.ts)",
-      "Write(**/*.php)",
-      "Write(**/*.css)",
-      "Write(**/*.blade.php)",
-      "Write(**/*.json)",
-      "Write(**/*.md)",
       "Read(**/*.md)",
-      "Edit(/.claude/skills/**)",
+      "Edit(.claude/skills/**)",
       "Edit(**/*.tsx)",
       "Edit(**/*.ts)",
       "Edit(**/*.php)",
@@ -51,7 +43,6 @@
       "Bash(mkdir -p *)"
     ],
     "ask": [
-      "Write(**/CLAUDE.md)",
       "Edit(**/CLAUDE.md)"
     ],
     "deny": [
@@ -61,11 +52,8 @@
       "Read(./secrets/**)",
       "Bash(grep *.env)",
       "Bash(grep *.env.*)",
-      "Write(**/package.json)",
       "Edit(**/package.json)",
-      "Write(**/composer.json)",
       "Edit(**/composer.json)",
-      "Write(**/.claude/settings*.json)",
       "Edit(**/.claude/settings*.json)"
     ]
   },


### PR DESCRIPTION
## やったこと

- `permissions` から効果のない `Write(path)` ルール 8 件を削除
  - `Write(path)` はファイルパーミッションチェックにマッチせず、`Edit(path)` が Write を含む全ファイル編集ツールをカバーする仕様のため、これらのルールは記述されていても一切機能していなかった
  - 削除対象: allow の `.claude/skills/**` / `**/*.tsx` / `**/*.ts` / `**/*.php` / `**/*.css` / `**/*.blade.php` / `**/*.json` / `**/*.md`、ask の `**/CLAUDE.md`、deny の `**/package.json` / `**/composer.json` / `**/.claude/settings*.json`
  - いずれも対応する `Edit(...)` ルールが既に存在するため、実効的な権限は変更前後で変わらない
- `Edit(/.claude/skills/**)` → `Edit(.claude/skills/**)` に修正
  - 先頭のスラッシュによりファイルシステムのルート直下 (`/.claude/skills`) を指す絶対パス扱いとなり、プロジェクトの `.claude/skills` にマッチしていなかった

## 結果

Claude Code 起動時に出ていた以下のような警告が解消される。

```
Permission allow rule (.claude/settings.json): Write(**/*.tsx) is not matched by
file permission checks — only Edit(path) rules are. Use Edit(**/*.tsx) instead
(Edit rules cover all file-editing tools).
```

## 動作確認済み

- [x] 変更が `.claude/settings.json` のみで、アプリケーションコードに影響がないことを確認
- [x] 削除した `Write(...)` ルールすべてに対応する `Edit(...)` ルールが残っていることを確認